### PR TITLE
Support to ETW Interfacing

### DIFF
--- a/PersistenceSniper/PersistenceSniper.psm1
+++ b/PersistenceSniper/PersistenceSniper.psm1
@@ -35,8 +35,7 @@
 
 #Requires -RunAsAdministrator
 
-function Find-AllPersistence
-{ 
+function Find-AllPersistence { 
   <#
       .SYNOPSIS
       Find-AllPersistence is PersistenceSniper's main function. All the other functions defined in it are used by Find-AllPersistence to gather information on potential persistence techniques implanted on the machines PersistenceSniper is run on.
@@ -94,61 +93,65 @@ function Find-AllPersistence
       .EXAMPLE
       Find-AllPersistence -DiffCSV .\persistences.csv -OutputCSV .\findings.csv | Where-Object Classification -Like "MITRE ATT&CK T*"
       Enumerate all persistence techniques implanted on the local machine, filter out the ones in the persistences.csv file, save the results in findings.csv and output to console only the persistences which are classified under the MITRE ATT&CK framework.
+  
+      .EXAMPLE
+      Find-AllPersistence -OutputETW 
+      Enumerate low false positive persistence techniques implanted on the local machine and output to Event Tracing for Windows.
   #>
   
   Param(
     [Parameter(Position = 0)]
     [ValidateSet(
-        'All',    
-        'RunAndRunOnce',
-        'ImageFileExecutionOptions',
-        'NLDPDllOverridePath',
-        'AeDebug',
-        'WerFaultHangs',
-        'CmdAutoRun',
-        'ExplorerLoad',
-        'WinlogonUserinit',
-        'WinlogonShell',
-        'TerminalProfileStartOnUserLogin',
-        'AppCertDlls',
-        'ServiceDlls',
-        'GPExtensionDlls',
-        'WinlogonMPNotify',
-        'CHMHelperDll',
-        'HHCtrlHijacking',
-        'StartupPrograms',
-        'UserInitMprScript',
-        'AutodialDLL',
-        'LsaExtensions',
-        'ServerLevelPluginDll',
-        'LsaPasswordFilter',
-        'LsaAuthenticationPackages',
-        'LsaSecurityPackages',
-        'WinlogonNotificationPackages',
-        'ExplorerTools',
-        'DotNetDebugger',
-        'ErrorHandlerCmd',
-        'WMIEventsSubscrition',
-        'WindowsServices',
-        'AppPaths',
-        'TerminalServicesInitialProgram',
-        'AccessibilityTools',
-        'AMSIProviders',
-        'PowershellProfiles',
-        'SilentExitMonitor',
-        'TelemetryController',
-        'RDPWDSStartupPrograms',
-        'ScheduledTasks',
-        'BitsJobsNotify',
-        'Screensaver',
-        'PowerAutomate',
-        'OfficeAddinsAndTemplates',
-        'Services',
-        'ExplorerContextMenu',
-        'ServiceControlManagerSD',
-        'OfficeAiHijacking',
-        'RunExAndRunOnceEx',
-        'DotNetStartupHooks'
+      'All',    
+      'RunAndRunOnce',
+      'ImageFileExecutionOptions',
+      'NLDPDllOverridePath',
+      'AeDebug',
+      'WerFaultHangs',
+      'CmdAutoRun',
+      'ExplorerLoad',
+      'WinlogonUserinit',
+      'WinlogonShell',
+      'TerminalProfileStartOnUserLogin',
+      'AppCertDlls',
+      'ServiceDlls',
+      'GPExtensionDlls',
+      'WinlogonMPNotify',
+      'CHMHelperDll',
+      'HHCtrlHijacking',
+      'StartupPrograms',
+      'UserInitMprScript',
+      'AutodialDLL',
+      'LsaExtensions',
+      'ServerLevelPluginDll',
+      'LsaPasswordFilter',
+      'LsaAuthenticationPackages',
+      'LsaSecurityPackages',
+      'WinlogonNotificationPackages',
+      'ExplorerTools',
+      'DotNetDebugger',
+      'ErrorHandlerCmd',
+      'WMIEventsSubscrition',
+      'WindowsServices',
+      'AppPaths',
+      'TerminalServicesInitialProgram',
+      'AccessibilityTools',
+      'AMSIProviders',
+      'PowershellProfiles',
+      'SilentExitMonitor',
+      'TelemetryController',
+      'RDPWDSStartupPrograms',
+      'ScheduledTasks',
+      'BitsJobsNotify',
+      'Screensaver',
+      'PowerAutomate',
+      'OfficeAddinsAndTemplates',
+      'Services',
+      'ExplorerContextMenu',
+      'ServiceControlManagerSD',
+      'OfficeAiHijacking',
+      'RunExAndRunOnceEx',
+      'DotNetStartupHooks'
     )]
     $PersistenceMethod = 'All',
      
@@ -169,6 +172,10 @@ function Find-AllPersistence
     $OutputCSV = $null, 
 
     [Parameter(Position = 5)]
+    [Switch]
+    $OutputETW = $null, 
+    
+    [Parameter(Position = 6)]
     [String]
     $VTApiKey = $null 
   )
@@ -184,12 +191,10 @@ function Find-AllPersistence
     $systemHive = (Get-Item Registry::HKEY_LOCAL_MACHINE).PSpath
     $null = $systemAndUsersHives.Add($systemHive)
     $sids = Get-ChildItem Registry::HKEY_USERS 
-    foreach($sid in $sids)
-    {
+    foreach ($sid in $sids) {
       $null = $systemAndUsersHives.Add($sid.PSpath)
     }
-    function New-PersistenceObject
-    {
+    function New-PersistenceObject {
       param(
         [String]
         $Hostname = $null,
@@ -231,28 +236,26 @@ function Find-AllPersistence
       $Executable = Get-ExecutableFromCommandLine $Value
       
       $PersistenceObject = [PSCustomObject]@{
-        'Hostname' 			  = $Hostname
-        'Technique'    		= $Technique
-        'Classification' 	= $Classification
-        'Path'         		= $Path
-        'Value'       	 	= $Value
-        'Access Gained' 	= $AccessGained
-        'Note'         		= $Note
-        'Reference'    		= $Reference
-        'Signature'	  		= Find-CertificateInfo $Executable
+        'Hostname'        = $Hostname
+        'Technique'       = $Technique
+        'Classification'  = $Classification
+        'Path'            = $Path
+        'Value'           = $Value
+        'Access Gained'   = $AccessGained
+        'Note'            = $Note
+        'Reference'       = $Reference
+        'Signature'       = Find-CertificateInfo $Executable
         'IsBuiltinBinary'	= Get-IfBuiltinBinary $Executable
-        'IsLolbin'			= Get-IfLolBin $Executable
-        'VTEntries'			= Get-IfHashIsMalicious $Executable
+        'IsLolbin'        = Get-IfLolBin $Executable
+        'VTEntries'       = Get-IfHashIsMalicious $Executable
       } 
       return $PersistenceObject
     }
     
-    function Get-IfHashIsMalicious($executable)
-    {
+    function Get-IfHashIsMalicious($executable) {
       $authenticode = Get-AuthenticodeSignature($executable)
       if ($authenticode.IsOSBinary -eq $false) {
-        if ($VTApiKey)
-        {
+        if ($VTApiKey) {
           $headers = @{
             'x-apikey' = $VTApiKey
           }
@@ -261,7 +264,8 @@ function Find-AllPersistence
           Sleep 1
           if ($result.data) {
             $result.data.attributes.last_analysis_stats.malicious
-          } else {
+          }
+          else {
             return "0"
           }
         }
@@ -276,8 +280,7 @@ function Find-AllPersistence
     }
 	
 	
-    function Get-IfLolBin
-    {
+    function Get-IfLolBin {
       param(
         [String]
         $executable
@@ -285,7 +288,7 @@ function Find-AllPersistence
       # To get an updated list of lolbins 
       # curl https://lolbas-project.github.io/# | grep -E "bin-name\">(.*)\.exe<" -o | cut -d ">" -f 2 | cut -d "<" -f 1 
       [String[]]$lolbins = "APPINSTALLER.EXE", "ASPNET_COMPILER.EXE", "AT.EXE", "ATBROKER.EXE", "BASH.EXE", "BITSADMIN.EXE", "CERTOC.EXE", "CERTREQ.EXE", "CERTUTIL.EXE", "CMD.EXE", "CMDKEY.EXE", "CMDL32.EXE", "CMSTP.EXE", "CONFIGSECURITYPOLICY.EXE", "CONHOST.EXE", "CONTROL.EXE", "CSC.EXE", "CSCRIPT.EXE", "DATASVCUTIL.EXE", "DESKTOPIMGDOWNLDR.EXE", "DFSVC.EXE", "DIANTZ.EXE", "DISKSHADOW.EXE", "DNSCMD.EXE", "ESENTUTL.EXE", "EVENTVWR.EXE", "EXPAND.EXE", "EXPLORER.EXE", "EXTEXPORT.EXE", "EXTRAC32.EXE", "FINDSTR.EXE", "FINGER.EXE", "FLTMC.EXE", "FORFILES.EXE", "FTP.EXE", "GFXDOWNLOADWRAPPER.EXE", "GPSCRIPT.EXE", "HH.EXE", "IMEWDBLD.EXE", "IE4UINIT.EXE", "IEEXEC.EXE", "ILASM.EXE", "INFDEFAULTINSTALL.EXE", "INSTALLUTIL.EXE", "JSC.EXE", "MAKECAB.EXE", "MAVINJECT.EXE", "MICROSOFT.WORKFLOW.COMPILER.EXE", "MMC.EXE", "MPCMDRUN.EXE", "MSBUILD.EXE", "MSCONFIG.EXE", "MSDT.EXE", "MSHTA.EXE", "MSIEXEC.EXE", "NETSH.EXE", "ODBCCONF.EXE", "OFFLINESCANNERSHELL.EXE", "ONEDRIVESTANDALONEUPDATER.EXE", "PCALUA.EXE", "PCWRUN.EXE", "PKTMON.EXE", "PNPUTIL.EXE", "PRESENTATIONHOST.EXE", "PRINT.EXE", "PRINTBRM.EXE", "PSR.EXE", "RASAUTOU.EXE", "RDRLEAKDIAG.EXE", "REG.EXE", "REGASM.EXE", "REGEDIT.EXE", "REGINI.EXE", "REGISTER-CIMPROVIDER.EXE", "REGSVCS.EXE", "REGSVR32.EXE", "REPLACE.EXE", "RPCPING.EXE", "RUNDLL32.EXE", "RUNONCE.EXE", "RUNSCRIPTHELPER.EXE", "SC.EXE", "SCHTASKS.EXE", "SCRIPTRUNNER.EXE", "SETTINGSYNCHOST.EXE", "STORDIAG.EXE", "SYNCAPPVPUBLISHINGSERVER.EXE", "TTDINJECT.EXE", "TTTRACER.EXE", "VBC.EXE", "VERCLSID.EXE", "WAB.EXE", "WLRMDR.EXE", "WMIC.EXE", "WORKFOLDERS.EXE", "WSCRIPT.EXE", "WSRESET.EXE", "WUAUCLT.EXE", "XWIZARD.EXE", "ACCCHECKCONSOLE.EXE", "ADPLUS.EXE", "AGENTEXECUTOR.EXE", "APPVLP.EXE", "BGINFO.EXE", "CDB.EXE", "COREGEN.EXE", "CSI.EXE", "DEVTOOLSLAUNCHER.EXE", "DNX.EXE", "DOTNET.EXE", "DUMP64.EXE", "DXCAP.EXE", "EXCEL.EXE", "FSI.EXE", "FSIANYCPU.EXE", "MFTRACE.EXE", "MSDEPLOY.EXE", "MSXSL.EXE", "NTDSUTIL.EXE", "POWERPNT.EXE", "PROCDUMP(64).EXE", "RCSI.EXE", "REMOTE.EXE", "SQLDUMPER.EXE", "SQLPS.EXE", "SQLTOOLSPS.EXE", "SQUIRREL.EXE", "TE.EXE", "TRACKER.EXE", "UPDATE.EXE", "VSIISEXELAUNCHER.EXE", "VISUALUIAVERIFYNATIVE.EXE", "VSJITDEBUGGER.EXE", "WFC.EXE", "WINWORD.EXE", "WSL.EXE"
-      foreach($lolbin in $lolbins){
+      foreach ($lolbin in $lolbins) {
         $exe = Split-Path -path $executable -Leaf
         if (($exe.ToUpper()) -eq $lolbin) {
           return $true
@@ -294,20 +297,17 @@ function Find-AllPersistence
       return $false
     }
 
-    function Get-IfBuiltinBinary
-    {
+    function Get-IfBuiltinBinary {
       param(
         [String]
         $executable
       )
       try {
         $authenticode = Get-AuthenticodeSignature $executable
-        if($authenticode.IsOsBinary)
-        {
+        if ($authenticode.IsOsBinary) {
           return $true
         }
-        else
-        {
+        else {
           return $false
         }
       } 
@@ -316,23 +316,21 @@ function Find-AllPersistence
       }
     }
 	
-    function Find-CertificateInfo
-    {
+    function Find-CertificateInfo {
       param(
         [String]
         $executable
       )
       try {
         $authenticode = Get-AuthenticodeSignature $executable
-        $formattedString = [string]::Format("Status = {0}, Subject = {1}",$authenticode.Status, $authenticode.SignerCertificate.Subject)
+        $formattedString = [string]::Format("Status = {0}, Subject = {1}", $authenticode.Status, $authenticode.SignerCertificate.Subject)
         return $formattedString
       } 
       catch { 
         return "Unknown error occurred"
       }
     }
-    function Get-ExecutableFromCommandLine 
-    {
+    function Get-ExecutableFromCommandLine {
       param(
         [String]
         $pathName
@@ -340,8 +338,7 @@ function Find-AllPersistence
       $pathName = [System.Environment]::ExpandEnvironmentVariables($pathName) -Replace '"'
       
       $match = [regex]::Match($pathName, '[A-Za-z0-9\s]+\.(exe|dll|ocx|cmd|bat|ps1)', [Text.RegularExpressions.RegexOptions]::IgnoreCase)
-      if($match.Success)
-      {
+      if ($match.Success) {
         # Grab Index from the [regex]::Match() result
         $Index = $Match.Index
 
@@ -349,82 +346,66 @@ function Find-AllPersistence
         $ThingsBeforeMatch = $pathName.Substring(0, $Index)
         $path = "$ThingsBeforeMatch$match"
       }
-      else
-      {
+      else {
         $path = $null
       }
       
-      if(([System.IO.Path]::IsPathRooted($path)) -eq $false)
-      {
+      if (([System.IO.Path]::IsPathRooted($path)) -eq $false) {
         $path = (Get-Command $path).Source
       }
       return $path
     }
-    function Get-IfSafeExecutable
-    {
+    function Get-IfSafeExecutable {
       param(
         [String]
         $executable
       )
     
       $exePath = Get-ExecutableFromCommandLine $executable
-      if((Get-IfBuiltinBinary $exePath) -and -not (Get-IfLolBin $exePath) )
-      {
+      if ((Get-IfBuiltinBinary $exePath) -and -not (Get-IfLolBin $exePath) ) {
         return $true
       }
-      else
-      {
+      else {
         return $false
       }
     }
     
-    function Get-IfSafeLibrary
-    {
+    function Get-IfSafeLibrary {
       param(
         [String]
         $dllFullPath
       )
       
-      if((Get-IfBuiltinBinary $dllFullPath) -eq $true)
-      {
+      if ((Get-IfBuiltinBinary $dllFullPath) -eq $true) {
         return $true
       }
-      else
-      {
+      else {
         return $false
       }
     }
 
-    function Get-RunAndRunOnce
-    {
+    function Get-RunAndRunOnce {
       Write-Verbose -Message "$hostname - Getting Run properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         
         $runProps = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" 
-        if($runProps)
-        {
+        if ($runProps) {
           Write-Verbose -Message "$hostname - [!] Found properties under $(Convert-Path -Path $hive)'s Run key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runProps))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runProps)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $runProps.PSPath
             $propPath += '\' + $prop.Name
             $currentHive = Convert-Path -Path $hive
-            if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-            {
+            if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
               $access = 'System'
             }
-            else
-            {
+            else {
               $access = 'User'
             }
-            
-            if(Get-IfSafeExecutable $runProps.($prop.Name))
-            {
+           
+            if (Get-IfSafeExecutable $runProps.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Registry Run Key' -Classification 'MITRE ATT&CK T1547.001' -Path $propPath -Value $runProps.($prop.Name) -AccessGained $access -Note 'Executables in properties of the key (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\CurrentVersion\Run are run when the user logs in or when the machine boots up (in the case of the HKLM hive).' -Reference 'https://attack.mitre.org/techniques/T1547/001/' 
@@ -435,31 +416,24 @@ function Find-AllPersistence
     
       Write-Verbose -Message ''
       Write-Verbose -Message "$hostname - Getting RunOnce properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $runOnceProps = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" 
-        if($runOnceProps)
-        {
+        if ($runOnceProps) {
           Write-Verbose -Message "$hostname - [!] Found properties under $(Convert-Path -Path $hive)'s RunOnce key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runOnceProps))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runOnceProps)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $runOnceProps.PSPath
             $propPath += '\' + $prop.Name
             $currentHive = Convert-Path -Path $hive
-            if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-            {
+            if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
               $access = 'System'
             }
-            else
-            {
+            else {
               $access = 'User'
             }
-            if(Get-IfSafeExecutable $runOnceProps.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $runOnceProps.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Registry RunOnce Key' -Classification 'MITRE ATT&CK T1547.001' -Path $propPath -Value $runOnceProps.($prop.Name) -AccessGained $access -Note 'Executables in properties of the key (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce are run once when the user logs in, or when the machine boots up (in the case of the HKLM hive), and then deleted.' -Reference 'https://attack.mitre.org/techniques/T1547/001/' 
@@ -470,42 +444,32 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-ImageFileExecutionOptions
-    {
+    function Get-ImageFileExecutionOptions {
       $IFEOptsDebuggers = New-Object -TypeName System.Collections.ArrayList
       $foundDangerousIFEOpts = $false
       Write-Verbose -Message "$hostname - Getting Image File Execution Options..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $ifeOpts = Get-ChildItem -Path "$hive\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options" 
-        if($ifeOpts)
-        {
-          foreach($key in $ifeOpts)
-          {
+        if ($ifeOpts) {
+          foreach ($key in $ifeOpts) {
             $debugger = Get-ItemProperty -Path Registry::$key -Name Debugger 
-            if($debugger) 
-            {
+            if ($debugger) {
               $foundDangerousIFEOpts = $true
               $null = $IFEOptsDebuggers.Add($key)
             }
           }
       
-          if($foundDangerousIFEOpts)
-          {
+          if ($foundDangerousIFEOpts) {
             Write-Verbose -Message "$hostname - [!] Found subkeys under the Image File Execution Options key of $(Convert-Path -Path $hive) which deserve investigation!"
-            foreach($key in $IFEOptsDebuggers)
-            {
+            foreach ($key in $IFEOptsDebuggers) {
               $ifeProps = Get-ItemProperty -Path Registry::$key -Name Debugger
-              foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $ifeProps))
-              {
-                if($psProperties.Contains($prop.Name)) 
-                {
+              foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $ifeProps)) {
+                if ($psProperties.Contains($prop.Name)) {
                   continue
                 } # skip the property if it's powershell built-in property
                 $propPath = Convert-Path -Path $ifeProps.PSPath
                 $propPath += '\' + $prop.Name
-                if(Get-IfSafeExecutable $ifeProps.($prop.Name))
-                {
+                if (Get-IfSafeExecutable $ifeProps.($prop.Name)) {
                   continue
                 }
                 $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Image File Execution Options' -Classification 'MITRE ATT&CK T1546.012' -Path $propPath -Value $ifeProps.($prop.Name) -AccessGained 'System/User' -Note 'Executables in the Debugger property of a subkey of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\ are run instead of the program corresponding to the subkey. Gained access depends on whose context the debugged process runs in.' -Reference 'https://attack.mitre.org/techniques/T1546/012/' 
@@ -518,51 +482,39 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-NLDPDllOverridePath
-    {
+    function Get-NLDPDllOverridePath {
       $KeysWithDllOverridePath = New-Object -TypeName System.Collections.ArrayList
       $foundDllOverridePath = $false
       Write-Verbose -Message "$hostname - Getting Natural Language Development Platform DLL path override properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $NLDPLanguages = Get-ChildItem -Path "$hive\SYSTEM\CurrentControlSet\Control\ContentIndex\Language" 
-        if($NLDPLanguages)
-        {
-          foreach($key in $NLDPLanguages)
-          {
+        if ($NLDPLanguages) {
+          foreach ($key in $NLDPLanguages) {
             $DllOverridePath = Get-ItemProperty -Path Registry::$key -Name *DLLPathOverride 
-            if($DllOverridePath) 
-            {
+            if ($DllOverridePath) {
               $foundDllOverridePath = $true
               $null = $KeysWithDllOverridePath.Add($key)
             }
           }
       
-          if($foundDllOverridePath)
-          {
+          if ($foundDllOverridePath) {
             Write-Verbose -Message "$hostname - [!] Found subkeys under $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Control\ContentIndex\Language which deserve investigation!"
-            foreach($key in $KeysWithDllOverridePath)
-            {
+            foreach ($key in $KeysWithDllOverridePath) {
               $properties = Get-ItemProperty -Path Registry::$key | Select-Object -Property *DLLPathOverride, PS*
-              foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $properties))
-              {
-                if($psProperties.Contains($prop.Name)) 
-                {
+              foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $properties)) {
+                if ($psProperties.Contains($prop.Name)) {
                   continue
                 } # skip the property if it's powershell built-in property
                 $propPath = Convert-Path -Path $properties.PSPath
                 $propPath += '\' + $prop.Name
                 $currentHive = Convert-Path -Path $hive
-                if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-                {
+                if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
                   $access = 'System'
                 }
-                else
-                {
+                else {
                   $access = 'User'
                 }
-                if(Get-IfSafeLibrary $properties.($prop.Name))
-                {
+                if (Get-IfSafeLibrary $properties.($prop.Name)) {
                   continue
                 }
                 $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Natural Language Development Platform 6 DLL Override Path' -Classification 'Hexacorn Technique N.98' -Path $propPath -Value $properties.($prop.Name) -AccessGained $access -Note 'DLLs listed in properties of subkeys of (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Control\ContentIndex\Language are loaded via LoadLibrary executed by SearchIndexer.exe' -Reference 'https://www.hexacorn.com/blog/2018/12/30/beyond-good-ol-run-key-part-98/'
@@ -575,25 +527,19 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-AeDebug
-    {
+    function Get-AeDebug {
       Write-Verbose -Message "$hostname - Getting AeDebug properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $aeDebugger = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" -Name Debugger 
-        if($aeDebugger)
-        {
+        if ($aeDebugger) {
           Write-Verbose -Message "$hostname - [!] Found properties under the $(Convert-Path -Path $hive) AeDebug key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $aeDebugger))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $aeDebugger)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $aeDebugger.PSPath
             $propPath += '\' + $prop.Name
-            if(Get-IfSafeExecutable $aeDebugger.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $aeDebugger.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'AEDebug Custom Debugger' -Classification 'Hexacorn Technique N.4' -Path $propPath -Value $aeDebugger.($prop.Name) -AccessGained 'System/User' -Note "The executable in the Debugger property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug is run when a process crashes. Gained access depends on whose context the debugged process runs in; if the Auto property of the same registry key is set to 1, the debugger starts without user interaction. A value of 'C:\Windows\system32\vsjitdebugger.exe' might be a false positive if you have Visual Studio Community installed." -Reference 'https://www.hexacorn.com/blog/2013/09/19/beyond-good-ol-run-key-part-4/' 
@@ -602,19 +548,15 @@ function Find-AllPersistence
         }
     
         $aeDebugger = Get-ItemProperty -Path "$hive\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug" -Name Debugger 
-        if($aeDebugger)
-        {
+        if ($aeDebugger) {
           Write-Verbose -Message "$hostname - [!] Found properties under the $(Convert-Path -Path $hive) Wow6432Node AeDebug key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $aeDebugger))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $aeDebugger)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $aeDebugger.PSPath
             $propPath += '\' + $prop.Name
-            if(Get-IfSafeExecutable $aeDebugger.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $aeDebugger.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Wow6432Node AEDebug Custom Debugger' -Classification 'Hexacorn Technique N.4' -Path $propPath -Value $aeDebugger.($prop.Name) -AccessGained 'System/User' -Note "The executable in the Debugger property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug is run when a 32 bit process on a 64 bit system crashes. Gained access depends on whose context the debugged process runs in; if the Auto property of the same registry key is set to 1, the debugger starts without user interaction. A value of 'C:\Windows\system32\vsjitdebugger.exe' might be a false positive if you have Visual Studio Community installed." -Reference 'https://www.hexacorn.com/blog/2013/09/19/beyond-good-ol-run-key-part-4/'
@@ -625,26 +567,20 @@ function Find-AllPersistence
       Write-Verbose -Message '' 
     }
   
-    function Get-WerFaultHangs
-    {
+    function Get-WerFaultHangs {
       Write-Verbose -Message "$hostname - Getting WerFault Hangs registry key Debug property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $werfaultDebugger = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows\Windows Error Reporting\Hangs" -Name Debugger 
-        if($werfaultDebugger)
-        {
+        if ($werfaultDebugger) {
           Write-Verbose -Message "$hostname - [!] Found a Debugger property under the $(Convert-Path -Path $hive) WerFault Hangs key which deserve investigation!"
           $werfaultDebugger | Select-Object -Property Debugger, PS*
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $werfaultDebugger))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $werfaultDebugger)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $werfaultDebugger.PSPath
             $propPath += '\' + $prop.Name
-            if(Get-IfSafeExecutable $werfaultDebugger.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $werfaultDebugger.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Windows Error Reporting Debugger' -Classification 'Hexacorn Technique N.116' -Path $propPath -Value $werfaultDebugger.($prop.Name) -AccessGained 'System' -Note 'The executable in the Debugger property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\Windows Error Reporting\Hangs is spawned by WerFault.exe when a process crashes.' -Reference 'https://www.hexacorn.com/blog/2019/09/20/beyond-good-ol-run-key-part-116/'
@@ -655,23 +591,18 @@ function Find-AllPersistence
     
       Write-Verbose -Message ''
       Write-Verbose -Message "$hostname - Getting WerFault Hangs registry key ReflectDebug property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $werfaultReflectDebugger = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows\Windows Error Reporting\Hangs" -Name ReflectDebugger 
-        if($werfaultReflectDebugger)
-        {
+        if ($werfaultReflectDebugger) {
           Write-Verbose -Message "$hostname - [!] Found a ReflectDebugger property under the $(Convert-Path -Path $hive) WerFault Hangs key which deserve investigation!"
           $werfaultReflectDebugger | Select-Object -Property ReflectDebugger, PS*
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $werfaultReflectDebugger))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $werfaultReflectDebugger)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $werfaultReflectDebugger.PSPath
             $propPath += '\' + $prop.Name
-            if(Get-IfSafeExecutable $werfaultReflectDebugger.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $werfaultReflectDebugger.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Windows Error Reporting ReflectDebugger' -Classification 'Hexacorn Technique N.85' -Path $propPath -Value $werfaultReflectDebugger.($prop.Name) -AccessGained 'System' -Note 'The executable in the ReflectDebugger property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\Windows Error Reporting\Hangs is spawned by WerFault.exe when called with the -pr argument.' -Reference 'https://www.hexacorn.com/blog/2018/08/31/beyond-good-ol-run-key-part-85/'
@@ -682,14 +613,11 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
 
-    function Get-CmdAutoRun
-    {
+    function Get-CmdAutoRun {
       Write-Verbose -Message "$hostname - Getting Command Processor's AutoRun property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $autorun = (Get-ItemProperty -Path "$hive\Software\Microsoft\Command Processor" -Name AutoRun).AutoRun
-        if($autorun)
-        {
+        if ($autorun) {
           Write-Verbose -Message "$hostname - [!] $(Convert-Path -Path $hive) Command Processor's AutoRun property is set and deserves investigation!"
           $propPath = Convert-Path -Path $hive
           $propPath += "\Software\Microsoft\Command Processor\AutoRun"
@@ -700,34 +628,26 @@ function Find-AllPersistence
       }
       Write-Verbose -Message ''   
     }  
-    function Get-ExplorerLoad
-    {
+    function Get-ExplorerLoad {
       Write-Verbose -Message "$hostname - Getting Explorer's Load property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $loadKey = Get-ItemProperty -Path "$hive\Software\Microsoft\Windows NT\CurrentVersion\Windows" -Name Load 
-        if($loadKey)
-        {
+        if ($loadKey) {
           Write-Verbose -Message "$hostname - [!] $(Convert-Path -Path $hive) Load property is set and deserves investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $loadKey))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $loadKey)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $loadKey.PSPath
             $propPath += '\' + $prop.Name
             $currentHive = Convert-Path -Path $hive
-            if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-            {
+            if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
               $access = 'System'
             }
-            else
-            {
+            else {
               $access = 'User'
             }
-            if(Get-IfSafeExecutable $loadKey.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $loadKey.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Explorer Load Property' -Classification 'Uncatalogued Technique N.2' -Path $propPath -Value $loadKey.($prop.Name) -AccessGained $access -Note 'The executable in the Load property of (HKLM|HKEY_USERS\<SID>)\Software\Microsoft\Windows NT\CurrentVersion\Windows is run by explorer.exe at login time.' -Reference 'https://persistence-info.github.io/Data/windowsload.html'
@@ -738,21 +658,15 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-WinlogonUserinit
-    {
+    function Get-WinlogonUserinit {
       Write-Verbose -Message "$hostname - Getting Winlogon's Userinit property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $userinit = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name Userinit 
-        if($userinit)
-        {
-          if($userinit.Userinit -ne 'C:\Windows\system32\userinit.exe,')
-          {
+        if ($userinit) {
+          if ($userinit.Userinit -ne 'C:\Windows\system32\userinit.exe,') {
             Write-Verbose -Message "$hostname - [!] $(Convert-Path -Path $hive) Winlogon's Userinit property is set to a non-standard value and deserves investigation!"
-            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $userinit))
-            {
-              if($psProperties.Contains($prop.Name)) 
-              {
+            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $userinit)) {
+              if ($psProperties.Contains($prop.Name)) {
                 continue
               } # skip the property if it's powershell built-in property
               $propPath = Convert-Path -Path $userinit.PSPath
@@ -766,22 +680,16 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-WinlogonShell
-    {        
+    function Get-WinlogonShell {        
       Write-Verbose -Message "$hostname - Getting Winlogon's Shell property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
 
         $shell = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name Shell 
-        if($shell)
-        {
-          if($shell.Shell -ne 'explorer.exe')
-          {
+        if ($shell) {
+          if ($shell.Shell -ne 'explorer.exe') {
             Write-Verbose -Message "$hostname - [!] $(Convert-Path -Path $hive) Winlogon's Shell property is set to a non-standard value and deserves investigation!"
-            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $shell))
-            {
-              if($psProperties.Contains($prop.Name)) 
-              {
+            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $shell)) {
+              if ($psProperties.Contains($prop.Name)) {
                 continue
               } # skip the property if it's a powershell built-in property
               $propPath = Convert-Path -Path $shell.PSPath
@@ -795,35 +703,26 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-TerminalProfileStartOnUserLogin
-    {
+    function Get-TerminalProfileStartOnUserLogin {
       Write-Verbose -Message "$hostname - Checking if users' Windows Terminal Profile's settings.json contains a startOnUserLogin value..."
       $userDirectories = Get-ChildItem -Path 'C:\Users\'
-      foreach($directory in $userDirectories)
-      {
+      foreach ($directory in $userDirectories) {
         $terminalDirectories = Get-ChildItem -Path "$($directory.FullName)\Appdata\Local\Packages\Microsoft.WindowsTerminal_*" 
-        foreach($terminalDirectory in $terminalDirectories)
-        {
+        foreach ($terminalDirectory in $terminalDirectories) {
           $settingsFile = Get-Content -Raw -Path "$($terminalDirectory.FullName)\LocalState\settings.json" | ConvertFrom-Json
-          if($settingsFile.startOnUserLogin -ne 'true') # skip to the next profile if startOnUserLogin is not present
-          {
+          if ($settingsFile.startOnUserLogin -ne 'true') { # skip to the next profile if startOnUserLogin is not present
             break 
           } 
           $defaultProfileGuid = $settingsFile.defaultProfile
           $found = $false 
-          foreach($profileList in $settingsFile.profiles)
-          {
-            foreach($profile in $profileList.list)
-            {
-              if($profile.guid -eq $defaultProfileGuid)
-              {
+          foreach ($profileList in $settingsFile.profiles) {
+            foreach ($profile in $profileList.list) {
+              if ($profile.guid -eq $defaultProfileGuid) {
                 Write-Verbose -Message "$hostname - [!] The file $($terminalDirectory.FullName)\LocalState\settings.json has the startOnUserLogin key set, the default profile has GUID $($profile.guid)!"
-                if($profile.commandline)
-                {
+                if ($profile.commandline) {
                   $executable = $profile.commandline 
                 }
-                else 
-                {
+                else {
                   $executable = $profile.name 
                 }
                 $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Windows Terminal startOnUserLogin' -Classification 'Uncatalogued Technique N.3' -Path "$($terminalDirectory.FullName)\LocalState\settings.json" -Value "$executable" -AccessGained 'User' -Note "The executable specified as value of the key `"commandline`" of a profile which has the `"startOnUserLogin`" key set to `"true`" in the Windows Terminal's settings.json of a user is run every time that user logs in." -Reference 'https://twitter.com/nas_bench/status/1550836225652686848'
@@ -832,8 +731,7 @@ function Find-AllPersistence
                 break
               }
             }
-            if ($found) 
-            {
+            if ($found) {
               break 
             } 
           }
@@ -842,18 +740,14 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-AppCertDlls
-    {
+    function Get-AppCertDlls {
       Write-Verbose -Message "$hostname - Getting AppCertDlls properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $appCertDllsProps = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\Session Manager\AppCertDlls" 
-        if($appCertDllsProps)
-        {
+        if ($appCertDllsProps) {
           Write-Verbose -Message "$hostname - [!] Found properties under $(Convert-Path -Path $hive) AppCertDlls key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $appCertDllsProps))
-          {
-            if($psProperties.Contains($prop.Name)) { continue } # skip the property if it's powershell built-in property
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $appCertDllsProps)) {
+            if ($psProperties.Contains($prop.Name)) { continue } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $appCertDllsProps.PSPath
             $propPath += '\' + $prop.Name
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'AppCertDlls' -Classification 'MITRE ATT&CK T1546.009' -Path $propPath -Value $appCertDllsProps.($prop.Name) -AccessGained 'System' -Note 'DLLs in properties of the key (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Control\Session Manager\AppCertDlls are loaded by every process that loads the Win32 API at process creation.' -Reference 'https://attack.mitre.org/techniques/T1546/009/'
@@ -864,29 +758,23 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-AppPaths
-    {
+    function Get-AppPaths {
       Write-Verbose -Message "$hostname - Getting App Paths inside the registry..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $appPathsKeys = Get-ChildItem -Path "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths" 
-        foreach($key in $appPathsKeys)
-        {
+        foreach ($key in $appPathsKeys) {
           $appPath = Get-ItemProperty -Path Registry::$key -Name '(Default)' 
           
           
           $exePath = $appPath.'(Default)'
-          if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($exePath))) -eq $false)
-          {
+          if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($exePath))) -eq $false) {
             $exePath = "C:\Windows\System32\$exePath"
           }
-          if ($exePath.Contains('powershell') -or $exePath.Contains('cmd') -or -not (Get-AuthenticodeSignature -FilePath $exePath ).IsOSBinary)
-          { 
+          if ($exePath.Contains('powershell') -or $exePath.Contains('cmd') -or -not (Get-AuthenticodeSignature -FilePath $exePath ).IsOSBinary) { 
             Write-Verbose -Message "$hostname - [!] Found subkeys under the $(Convert-Path -Path $hive) App Paths key which deserve investigation!"
             $propPath = Convert-Path -Path $key.PSPath
             $propPath += '\' + $appPath.Name
-            if(Get-IfSafeExecutable $appPath.'(Default)')
-            {
+            if (Get-IfSafeExecutable $appPath.'(Default)') {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'App Paths' -Classification 'Hexacorn Technique N.3' -Path "$propPath(Default)" -Value $appPath.'(Default)' -AccessGained 'System/User' -Note 'Executables in the (Default) property of a subkey of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\ are run instead of the program corresponding to the subkey. Gained access depends on whose context the process runs in. Be aware this might be a false positive.' -Reference 'https://www.hexacorn.com/blog/2013/01/19/beyond-good-ol-run-key-part-3/'
@@ -897,36 +785,26 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }  
   
-    function Get-ServiceDlls
-    {
+    function Get-ServiceDlls {
       Write-Verbose -Message "$hostname - Getting Service DLLs inside the registry..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $keys = Get-ChildItem -Path "$hive\SYSTEM\CurrentControlSet\Services\" 
-        foreach ($key in $keys)
-        {
+        foreach ($key in $keys) {
           $ImagePath = (Get-ItemProperty -Path ($key.pspath)).ImagePath
-          if ($null -ne $ImagePath)
-          {
-            if ($ImagePath.Contains('\svchost.exe'))
-            {    
-              if (Test-Path -Path ($key.pspath+'\Parameters'))
-              {
-                $ServiceDll = (Get-ItemProperty -Path ($key.pspath+'\Parameters')).ServiceDll
+          if ($null -ne $ImagePath) {
+            if ($ImagePath.Contains('\svchost.exe')) {    
+              if (Test-Path -Path ($key.pspath + '\Parameters')) {
+                $ServiceDll = (Get-ItemProperty -Path ($key.pspath + '\Parameters')).ServiceDll
               }
-              else
-              {
+              else {
                 $ServiceDll = (Get-ItemProperty -Path ($key.pspath)).ServiceDll
               }
-              if ($null -ne $ServiceDll)
-              {
+              if ($null -ne $ServiceDll) {
                 $dllPath = $ServiceDll
-                if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false)
-                {
+                if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false) {
                   $dllPath = "C:\Windows\System32\$dllPath"
                 }
-                if ((Get-IfSafeLibrary $dllPath) -EQ $false) 
-                {
+                if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
                   Write-Verbose -Message "$hostname - [!] Found subkeys under the $(Convert-Path -Path $hive) Services key which deserve investigation!"
                   $propPath = (Convert-Path -Path "$($key.pspath)") + '\Parameters\ServiceDll'
                   $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'ServiceDll Hijacking' -Classification 'Hexacorn Technique N.4' -Path $propPath -Value "$ServiceDll" -AccessGained 'System' -Note "DLLs in the ServiceDll property of (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Services\<SERVICE_NAME>\Parameters are loaded by the corresponding service's svchost.exe. If an attacker modifies said entry, the malicious DLL will be loaded in place of the legitimate one." -Reference 'https://www.hexacorn.com/blog/2013/09/19/beyond-good-ol-run-key-part-4/'
@@ -940,23 +818,17 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-GPExtensionDlls
-    {
+    function Get-GPExtensionDlls {
       Write-Verbose -Message "$hostname - Getting Group Policy Extension DLLs inside the registry..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $keys = Get-ChildItem -Path "$hive\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions" 
-        foreach ($key in $keys)
-        {
+        foreach ($key in $keys) {
           $DllName = (Get-ItemProperty -Path ($key.pspath)).DllName
-          if ($null -ne $DllName)
-          {
-            if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($DllName))) -eq $false)
-            {
+          if ($null -ne $DllName) {
+            if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($DllName))) -eq $false) {
               $DllName = "C:\Windows\System32\$DllName"
             }
-            if ((Get-IfSafeLibrary $DllName) -EQ $false) 
-            {
+            if ((Get-IfSafeLibrary $DllName) -EQ $false) {
               Write-Verbose -Message "$hostname - [!] Found DllName property under a subkey of the $(Convert-Path -Path $hive) GPExtensions key which deserve investigation!"
               $propPath = (Convert-Path -Path "$($key.pspath)") + '\DllName'
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Group Policy Extension DLL' -Classification 'Uncatalogued Technique N.4' -Path $propPath -Value "$DllName" -AccessGained 'System' -Note 'DLLs in the DllName property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions\<GUID>\ are loaded by the gpsvc process. If an attacker modifies said entry, the malicious DLL will be loaded in place of the legitimate one.' -Reference 'https://persistence-info.github.io/Data/gpoextension.html'
@@ -968,14 +840,11 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-WinlogonMPNotify
-    {
+    function Get-WinlogonMPNotify {
       Write-Verbose -Message "$hostname - Getting Winlogon MPNotify property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $mpnotify = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name mpnotify 
-        if($mpnotify)
-        {
+        if ($mpnotify) {
           Write-Verbose -Message "$hostname - [!] Found MPnotify property under $(Convert-Path -Path $hive) Winlogon key!"
           $propPath = (Convert-Path -Path $mpnotify.PSPath) + '\mpnotify'
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Winlogon MPNotify Executable' -Classification 'Uncatalogued Technique N.5' -Path $propPath -Value $mpnotify.mpnotify -AccessGained 'System' -Note 'The executable specified in the "mpnotify" property of the (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon key is run by Winlogon when a user logs on. After the timeout (30s) the process and its child processes are terminated.' -Reference 'https://persistence-info.github.io/Data/mpnotify.html'
@@ -985,23 +854,17 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-CHMHelperDll
-    {
+    function Get-CHMHelperDll {
       Write-Verbose -Message "$hostname - Getting CHM Helper DLL inside the registry..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $dllLocation = Get-ItemProperty -Path "$hive\Software\Microsoft\HtmlHelp Author" -Name Location
-        if($dllLocation)
-        {
+        if ($dllLocation) {
           $dllPath = $dllLocation.Location
-          if ($null -ne $dllPath)
-          {
-            if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false)
-            {
+          if ($null -ne $dllPath) {
+            if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false) {
               $dllPath = "C:\Windows\System32\$dllPath"
             }
-            if ((Get-IfSafeLibrary $dllPath) -EQ $false) 
-            {
+            if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
               Write-Verbose -Message "$hostname - [!] Found Location property under $(Convert-Path -Path $hive)\Software\Microsoft\HtmlHelp Author\ which deserve investigation!"
               $propPath = (Convert-Path -Path "$($dllLocation.pspath)") + '\Location'
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'CHM Helper DLL' -Classification 'Hexacorn Technique N.76' -Path $propPath -Value "$($dllLocation.Location)" -AccessGained 'User' -Note 'DLLs in the Location property of (HKLM|HKEY_USERS\<SID>)\Software\Microsoft\HtmlHelp Author\ are loaded when a CHM help file is parsed. If an attacker adds said entry, the malicious DLL will be loaded.' -Reference 'https://www.hexacorn.com/blog/2018/04/22/beyond-good-ol-run-key-part-76/'
@@ -1013,31 +876,25 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-HHCtrlHijacking
-    {
+    function Get-HHCtrlHijacking {
       Write-Verbose -Message "$hostname - Getting the hhctrl.ocx library inside the registry..."
       $hive = (Get-Item Registry::HKEY_CLASSES_ROOT).PSpath
       $dllLocation = Get-ItemProperty -Path "$hive\CLSID\{52A2AAAE-085D-4187-97EA-8C30DB990436}\InprocServer32" -Name '(Default)'
       $dllPath = $dllLocation.'(Default)'
-      if ($null -ne $dllPath)
-      {
-        if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false)
-        {
+      if ($null -ne $dllPath) {
+        if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false) {
           $dllPath = "C:\Windows\System32\$dllPath"
         }
-        if (-not (Get-AuthenticodeSignature -FilePath $dllPath ).IsOSBinary)
-        {
+        if (-not (Get-AuthenticodeSignature -FilePath $dllPath ).IsOSBinary) {
           Write-Verbose -Message "$hostname - [!] The DLL at $(Convert-Path -Path $hive)\CLSID\{52A2AAAE-085D-4187-97EA-8C30DB990436}\InprocServer32\(Default) is not an OS binary and deserves investigation!"
           $propPath = (Convert-Path -Path "$($dllLocation.pspath)") + '\(Default)'
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Hijacking of hhctrl.ocx' -Classification 'Hexacorn Technique N.77' -Path $propPath -Value "$($dllLocation.'(Default)')" -AccessGained 'User' -Note 'The DLL in the (Default) property of HKEY_CLASSES_ROOT\CLSID\{52A2AAAE-085D-4187-97EA-8C30DB990436}\InprocServer32 is loaded when a CHM help file is parsed or when hh.exe is started. If an attacker modifies said entry, the malicious DLL will be loaded. In case the loading fails for any reason, C:\Windows\hhctrl.ocx is loaded.' -Reference 'https://www.hexacorn.com/blog/2018/04/23/beyond-good-ol-run-key-part-77/'
           $null = $persistenceObjectArray.Add($PersistenceObject)
         }
       }
-      else
-      {
+      else {
         $dllPath = "C:\Windows\System32\hhctrl.ocx"
-        if (-not (Get-AuthenticodeSignature -FilePath $dllPath ).IsOSBinary)
-        {
+        if (-not (Get-AuthenticodeSignature -FilePath $dllPath ).IsOSBinary) {
           Write-Verbose -Message "$hostname - [!] The DLL at $dllPath is not an OS binary and deserves investigation!"
           $propPath = (Convert-Path -Path "$($dllLocation.pspath)") + '\(Default)'
           $PersistenceObject = New-PersistenceObject -Hostname "$hostname" -Technique 'Hijacking of hhctrl.ocx' -Classification 'Hexacorn Technique N.77' -Path "$dllPath" -Value "Not an OS binary" -AccessGained 'User' -Note 'The DLL in the (Default) property of HKEY_CLASSES_ROOT\CLSID\{52A2AAAE-085D-4187-97EA-8C30DB990436}\InprocServer32 is loaded when a CHM help file is parsed or when hh.exe is started. If an attacker modifies said entry, the malicious DLL will be loaded. In case the loading fails for any reason, C:\Windows\hhctrl.ocx is loaded.' -Reference 'https://www.hexacorn.com/blog/2018/04/23/beyond-good-ol-run-key-part-77/'
@@ -1047,21 +904,17 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-StartupPrograms
-    {
+    function Get-StartupPrograms {
       Write-Verbose -Message "$hostname - Checking if users' Startup folder contains interesting artifacts..."
       $userDirectories = Get-ChildItem -Path 'C:\Users\'
-      foreach($directory in $userDirectories)
-      {
+      foreach ($directory in $userDirectories) {
         $fullPath = $directory.FullName
         $startupDirectory = Get-ChildItem -Path "$fullPath\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\" 
-        foreach($file in $startupDirectory)
-        {
+        foreach ($file in $startupDirectory) {
           $relPath = $file.Name
           Write-Verbose -Message "$hostname - [!] Found a file under $fullPath\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\ folder!"
           $safeCheck = Get-IfSafeExecutable "$fullPath\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\$relPath"
-          if($safeCheck)
-          {
+          if ($safeCheck) {
             continue
           }          
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Startup Folder' -Classification 'MITRE ATT&CK T1547.001' -Path "$fullPath\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\" -Value "$fullPath\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\$relPath" -AccessGained 'User' -Note "The executables under the .\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\ of a user's folder are run every time that user logs in." -Reference 'https://attack.mitre.org/techniques/T1547/001/'
@@ -1073,23 +926,18 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-UserInitMprScript
-    {
+    function Get-UserInitMprScript {
       Write-Verbose -Message "$hostname - Getting users' UserInitMprLogonScript property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $mprlogonscript = Get-ItemProperty -Path "$hive\Environment" -Name UserInitMprLogonScript 
-        if($mprlogonscript)
-        {
+        if ($mprlogonscript) {
           Write-Verbose -Message "$hostname - [!] Found UserInitMprLogonScript property under $(Convert-Path -Path $hive)\Environment\ key!"
           $propPath = (Convert-Path -Path $mprlogonscript.PSPath) + '\UserInitMprLogonScript'
           $currentHive = Convert-Path -Path $hive
-          if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-          {
+          if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
             $access = 'System'
           }
-          else
-          {
+          else {
             $access = 'User'
           }
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'User Init Mpr Logon Script' -Classification 'MITRE ATT&CK T1037.001' -Path $propPath -Value $mprlogonscript.UserInitMprLogonScript -AccessGained $access -Note 'The executable specified in the "UserInitMprLogonScript" property of the HKEY_USERS\<SID>\Environment key is run when the user logs on.' -Reference 'https://attack.mitre.org/techniques/T1037/001/'
@@ -1099,21 +947,16 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-AutodialDLL
-    {
+    function Get-AutodialDLL {
       Write-Verbose -Message "$hostname - Getting the AutodialDLL property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $autodialDll = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Services\WinSock2\Parameters" -Name AutodialDLL 
-        if($autodialDll)
-        {
+        if ($autodialDll) {
           $dllPath = $autodialDll.AutodialDLL
-          if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false)
-          {
+          if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false) {
             $dllPath = "C:\Windows\System32\$dllPath"
           }
-          if ((Get-IfSafeLibrary $dllPath) -EQ $false)
-          {
+          if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
             Write-Verbose -Message "$hostname - [!] Found AutodialDLL property under $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Services\WinSock2\Parameters\ key which points to a non-OS DLL!"
             $propPath = (Convert-Path -Path $autodialDll.PSPath) + '\AutodialDLL'
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'AutodialDLL Winsock Injection' -Classification 'Hexacorn Technique N.24' -Path $propPath -Value $autodialDll.AutodialDLL -AccessGained 'System' -Note 'The DLL specified in the "AutodialDLL" property of the (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Services\WinSock2\Parameters key is loaded by the Winsock library everytime it connects to the internet.' -Reference 'https://www.hexacorn.com/blog/2015/01/13/beyond-good-ol-run-key-part-24/'
@@ -1124,24 +967,18 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-LsaExtensions
-    {
+    function Get-LsaExtensions {
       Write-Verbose -Message "$hostname - Getting LSA's extensions..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $lsaExtensions = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\LsaExtensionConfig\LsaSrv" -Name Extensions 
-        if($lsaExtensions)
-        {
+        if ($lsaExtensions) {
           $dlls = $lsaExtensions.Extensions -split '\s+'
-          foreach ($dll in $dlls)
-          {
+          foreach ($dll in $dlls) {
             $dllPath = $dll
-            if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false)
-            {
+            if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false) {
               $dllPath = "C:\Windows\System32\$dllPath"
             }
-            if ((Get-IfSafeLibrary $dllPath) -EQ $false)
-            {
+            if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
               Write-Verbose -Message "$hostname - [!] Found LSA Extension DLL under the $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Control\LsaExtensionConfig\LsaSrv\Extensions property which points to a non-OS DLL!"
               $propPath = (Convert-Path -Path $lsaExtensions.PSPath) + '\Extensions'
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'LSA Extensions DLL' -Classification 'Uncatalogued Technique N.6' -Path $propPath -Value $dll -AccessGained 'System' -Note 'The DLLs specified in the "Extensions" property of the (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Control\LsaExtensionConfig\LsaSrv\ key are loaded by LSASS at machine boot.' -Reference 'https://persistence-info.github.io/Data/lsaaextension.html'
@@ -1153,21 +990,16 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
   
-    function Get-ServerLevelPluginDll
-    {
+    function Get-ServerLevelPluginDll {
       Write-Verbose -Message "$hostname - Getting the ServerLevelPluginDll property..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $pluginDll = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Services\DNS\Parameters" -Name ServerLevelPluginDll 
-        if($pluginDll)
-        {
+        if ($pluginDll) {
           $dllPath = $pluginDll.ServerLevelPluginDll
-          if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false)
-          {
+          if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dllPath))) -eq $false) {
             $dllPath = "C:\Windows\System32\$dllPath"
           }
-          if ((Get-IfSafeLibrary $dllPath) -EQ $false)
-          {
+          if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
             Write-Verbose -Message "$hostname - [!] Found ServerLevelPluginDll property under $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Services\DNS\Parameters key which points to a non-OS DLL!"
             $propPath = (Convert-Path -Path $pluginDll.PSPath) + '\ServerLevelPluginDll'
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'ServerLevelPluginDll DNS Server DLL Hijacking' -Classification 'Uncatalogued Technique N.7' -Path $propPath -Value $pluginDll.ServerLevelPluginDll -AccessGained 'System' -Note 'The DLL specified in the "ServerLevelPluginDll" property of the (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Services\DNS\Parameters key is loaded by the DNS service on systems with the "DNS Server" role enabled.' -Reference 'https://persistence-info.github.io/Data/serverlevelplugindll.html'
@@ -1178,20 +1010,15 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-LsaPasswordFilter
-    {
+    function Get-LsaPasswordFilter {
       Write-Verbose -Message "$hostname - Getting LSA's password filters..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $passwordFilters = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\Lsa" -Name 'Notification Packages' 
-        if($passwordFilters)
-        {
+        if ($passwordFilters) {
           $dlls = $passwordFilters.'Notification Packages' -split '\s+'
-          foreach ($dll in $dlls)
-          {
+          foreach ($dll in $dlls) {
             $dllPath = "C:\Windows\System32\$dll.dll"
-            if ((Get-IfSafeLibrary $dllPath) -EQ $false)
-            {
+            if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
               Write-Verbose -Message "$hostname - [!] Found a LSA password filter DLL under the $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Control\Lsa\Notification Packages property which points to a non-OS DLL!"
               $propPath = (Convert-Path -Path $passwordFilters.PSPath) + '\Notification Packages'
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'LSA Password Filter DLL' -Classification 'MITRE ATT&CK T1556.002' -Path $propPath -Value $dllPath -AccessGained 'System' -Note 'The DLLs specified in the "Notification Packages" property of the (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Control\Lsa\ key are loaded by LSASS at machine boot.' -Reference 'https://attack.mitre.org/techniques/T1556/002/'
@@ -1203,20 +1030,15 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-LsaAuthenticationPackages
-    {
+    function Get-LsaAuthenticationPackages {
       Write-Verbose -Message "$hostname - Getting LSA's authentication packages..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $authPackages = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\Lsa" -Name 'Authentication Packages' 
-        if($authPackages)
-        {
+        if ($authPackages) {
           $dlls = $authPackages.'Authentication Packages' -split '\s+'
-          foreach ($dll in $dlls)
-          {
+          foreach ($dll in $dlls) {
             $dllPath = "C:\Windows\System32\$dll.dll"
-            if ((Get-IfSafeLibrary $dllPath) -EQ $false)
-            {
+            if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
               Write-Verbose -Message "$hostname - [!] Found a LSA authentication package DLL under the $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Control\Lsa\Authentication Packages property which points to a non-OS DLL!"
               $propPath = (Convert-Path -Path $authPackages.PSPath) + '\Authentication Packages'
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'LSA Authentication Package DLL' -Classification 'MITRE ATT&CK T1547.002' -Path $propPath -Value $dllPath -AccessGained 'System' -Note 'The DLLs specified in the "Authentication Packages" property of the (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Control\Lsa\ key are loaded by LSASS at machine boot.' -Reference 'https://attack.mitre.org/techniques/T1547/002/'
@@ -1228,28 +1050,21 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-LsaSecurityPackages
-    {
+    function Get-LsaSecurityPackages {
       Write-Verbose -Message "$hostname - Getting LSA's security packages..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $secPackages = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\Lsa" -Name 'Security Packages' 
-        if($secPackages)
-        {
-          $packageString = $secPackages.'Security Packages' -replace '"',''
+        if ($secPackages) {
+          $packageString = $secPackages.'Security Packages' -replace '"', ''
           $dlls = $packageString -split '\s+'
-          foreach ($dll in $dlls)
-          {
-            if($dll -eq "")
-            {
+          foreach ($dll in $dlls) {
+            if ($dll -eq "") {
               continue
             }
-            if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dll))) -eq $false)
-            {
+            if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($dll))) -eq $false) {
               $dll = "C:\Windows\System32\$dll.dll"
             }
-            if ((Get-IfSafeLibrary $dllPath) -EQ $false)
-            {
+            if ((Get-IfSafeLibrary $dllPath) -EQ $false) {
               Write-Verbose -Message "$hostname - [!] Found a LSA security package DLL under the $(Convert-Path -Path $hive)\SYSTEM\CurrentControlSet\Control\Lsa\Security Packages property which points to a non-OS DLL!"
               $propPath = (Convert-Path -Path $secPackages.PSPath) + '\Security Packages'
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'LSA Security Package DLL' -Classification 'MITRE ATT&CK T1547.005' -Path $propPath -Value $dll -AccessGained 'System' -Note 'The DLLs specified in the "Security Packages" property of the (HKLM|HKEY_USERS\<SID>)\SYSTEM\CurrentControlSet\Control\Lsa\ key are loaded by LSASS at machine boot.' -Reference 'https://attack.mitre.org/techniques/T1547/005/'
@@ -1261,20 +1076,15 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-WinlogonNotificationPackages
-    {
+    function Get-WinlogonNotificationPackages {
       Write-Verbose -Message "$hostname - Getting Winlogon Notification packages..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         
         $notificationPackages = Get-ItemProperty -Path "$hive\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify" 
-        if($notificationPackages)
-        {
+        if ($notificationPackages) {
           Write-Verbose -Message "$hostname - [!] Found properties under $(Convert-Path -Path $hive)\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $notificationPackages))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $notificationPackages)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $notificationPackages.PSPath
@@ -1287,21 +1097,16 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-ExplorerTools
-    {
+    function Get-ExplorerTools {
       Write-Verbose -Message "$hostname - Getting Explorer Tools..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $explorerTools = Get-ChildItem -Path "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer" 
-        foreach($key in $explorerTools)
-        {
-          $path = ((Get-ItemProperty -Path Registry::$key -Name '(Default)').'(Default)'-split '\s+')[0] # split the path and take only the executable in case there are arguments
-          if(('' -ne $path) -and ([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path)) -eq $false))
-          {
+        foreach ($key in $explorerTools) {
+          $path = ((Get-ItemProperty -Path Registry::$key -Name '(Default)').'(Default)' -split '\s+')[0] # split the path and take only the executable in case there are arguments
+          if (('' -ne $path) -and ([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path)) -eq $false)) {
             $path = "C:\Windows\System32\$path.dll"
           }
-          if (-not (Get-AuthenticodeSignature -FilePath $path ).IsOSBinary) 
-          {
+          if (-not (Get-AuthenticodeSignature -FilePath $path ).IsOSBinary) {
             Write-Verbose -Message "$hostname - [!] Found an executable under a subkey of $(Convert-Path -Path $hive)\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer key which deserve investigation!"
             $propPath = Convert-Path -Path $key.PSPath
             $propPath += '\(Default)'
@@ -1313,16 +1118,12 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-DotNetDebugger
-    {
+    function Get-DotNetDebugger {
       Write-Verbose -Message "$hostname - Getting .NET Debugger properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $dotNetDebugger = Get-ItemProperty -Path "$hive\SOFTWARE\Microsoft\.NETFramework" -Name DbgManagedDebugger 
-        if($dotNetDebugger.DbgManagedDebugger)
-        {          
-          if(Get-IfSafeExecutable $dotNetDebugger.DbgManagedDebugger)
-          {
+        if ($dotNetDebugger.DbgManagedDebugger) {          
+          if (Get-IfSafeExecutable $dotNetDebugger.DbgManagedDebugger) {
             continue
           }
           Write-Verbose -Message "$hostname - [!] Found DbgManagedDebugger under the $(Convert-Path -Path $hive)\SOFTWARE\Microsoft\.NETFramework key which deserve investigation!"
@@ -1334,10 +1135,8 @@ function Find-AllPersistence
         }
     
         $dotNetDebugger = Get-ItemProperty -Path "$hive\SOFTWARE\Wow6432Node\Microsoft\.NETFramework" -Name DbgManagedDebugger 
-        if($dotNetDebugger.DbgManagedDebugger)
-        {
-          if(Get-IfSafeExecutable $dotNetDebugger.DbgManagedDebugger)
-          {
+        if ($dotNetDebugger.DbgManagedDebugger) {
+          if (Get-IfSafeExecutable $dotNetDebugger.DbgManagedDebugger) {
             continue
           }
           Write-Verbose -Message "$hostname - [!] Found DbgManagedDebugger under the $(Convert-Path -Path $hive)\SOFTWARE\Wow6432Node\Microsoft\.NETFramework key which deserve investigation!"
@@ -1350,12 +1149,10 @@ function Find-AllPersistence
       Write-Verbose -Message '' 
     }
     
-    function Get-ErrorHandlerCmd
-    {
+    function Get-ErrorHandlerCmd {
       Write-Verbose -Message "$hostname - Checking if C:\WINDOWS\Setup\Scripts\ contains a file called ErrorHandler.cmd..."
       $errorHandlerCmd = Get-ChildItem -Path 'C:\WINDOWS\Setup\Scripts\ErrorHandler.cmd'
-      if($errorHandlerCmd)
-      {
+      if ($errorHandlerCmd) {
         Write-Verbose -Message "$hostname - [!] Found C:\WINDOWS\Setup\Scripts\ErrorHandler.cmd!"          
         $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'ErrorHandler.cmd Hijacking' -Classification 'Hexacorn Technique N.135' -Path "C:\WINDOWS\Setup\Scripts\" -Value "ErrorHandler.cmd" -AccessGained 'User' -Note "The content of C:\WINDOWS\Setup\Scripts\ErrorHandler.cmd is read whenever some tools under C:\WINDOWS\System32\oobe\ (e.g. Setup.exe) fail to run for any reason." -Reference 'https://www.hexacorn.com/blog/2022/01/16/beyond-good-ol-run-key-part-135/'
         $null = $persistenceObjectArray.Add($PersistenceObject)
@@ -1363,24 +1160,19 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
 
-    function Get-WMIEventsSubscrition
-    {
+    function Get-WMIEventsSubscrition {
       Write-Verbose -Message "$hostname - Checking WMI Subscriptions..."
       $cmdEventConsumer = Get-WMIObject -Namespace root\Subscription -Class CommandLineEventConsumer
-      if ($cmdEventConsumer)
-      {
-        foreach ( $cmdEntry in ($cmdEventConsumer))
-        {
+      if ($cmdEventConsumer) {
+        foreach ( $cmdEntry in ($cmdEventConsumer)) {
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'WMI Event Subscription' -Classification 'MITRE ATT&CK T1546.003' -Path $cmdEntry.__PATH -Value "CommandLineTemplate: $($cmdEntry.CommandLineTemplate) / ExecutablePath: $($cmdEntry.ExecutablePath)" -AccessGained 'System' -Note "WMI Events subscriptions can be used to link script/command executions to specific events. Here we list the active consumer events, but you may want to review also existing Filters (with Get-WMIObject -Namespace root\Subscription -Class __EventFilter) and Bindings (with Get-WMIObject -Namespace root\Subscription -Class __FilterToConsumerBinding)" -Reference 'https://attack.mitre.org/techniques/T1546/003/'
           $null = $persistenceObjectArray.Add($PersistenceObject)
         }
       }
 
       $scriptEventConsumer = Get-WMIObject -Namespace root\Subscription -Class ActiveScriptEventConsumer
-      if ($scriptEventConsumer)
-      {
-        foreach ( $scriptEntry in ($scriptEventConsumer))
-        {
+      if ($scriptEventConsumer) {
+        foreach ( $scriptEntry in ($scriptEventConsumer)) {
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'WMI Event Subscription' -Classification 'MITRE ATT&CK T1546.003' -Path $scriptEntry.__PATH -Value "ScriptingEngine: $($scriptEntry.ScriptingEngine) / ScriptFileName: $($scriptEntry.ScriptFileName) / ScriptText: $($scriptEntry.ScriptText)"  -AccessGained 'System' -Note "WMI Events subscriptions can be used to link script/command executions to specific events. Here we list the active consumer events, but you may want to review also existing Filters (with Get-WMIObject -Namespace root\Subscription -Class __EventFilter) and Bindings (with Get-WMIObject -Namespace root\Subscription -Class __FilterToConsumerBinding)" -Reference 'https://attack.mitre.org/techniques/T1546/003/'
           $null = $persistenceObjectArray.Add($PersistenceObject)
         }
@@ -1388,15 +1180,12 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
 	
-    function Get-WindowsServices
-    {
+    function Get-WindowsServices {
       Write-Verbose -Message "$hostname - Checking Windows Services..."
-      $services = Get-CimInstance -ClassName win32_service | Select-Object Name,DisplayName,State,PathName
-      foreach ( $service in $services) 
-      {
+      $services = Get-CimInstance -ClassName win32_service | Select-Object Name, DisplayName, State, PathName
+      foreach ( $service in $services) {
         $path = Get-ExecutableFromCommandLine $service.PathName
-        if ((Get-IfSafeExecutable $path) -EQ $false) 
-        {
+        if ((Get-IfSafeExecutable $path) -EQ $false) {
           Write-Verbose -Message "$hostname - [!] Found Windows Services which may deserve investigation..."
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Windows Service' -Classification 'MITRE ATT&CK T1543.003' -Path $service.Name  -Value $service.PathName  -AccessGained 'System' -Note "Adversaries may create or modify Windows services to repeatedly execute malicious payloads as part of persistence. When Windows boots up, it starts programs or applications called services that perform background system functions."  -Reference 'https://attack.mitre.org/techniques/T1543/003/'
           $null = $persistenceObjectArray.Add($PersistenceObject)
@@ -1405,15 +1194,13 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-PowerAutomate
-    {
+    function Get-PowerAutomate {
       Write-Verbose -Message "$hostname - Checking Power Automate presence..."
 
       $PADFolder = "$env:ProgramData\Microsoft\Power Automate\Logs"
-      $LastPALog = Get-ChildItem -Path $PADFolder | Sort-Object LastWriteTime -Descending| Select-Object -First 1
+      $LastPALog = Get-ChildItem -Path $PADFolder | Sort-Object LastWriteTime -Descending | Select-Object -First 1
 
-      if ($LastPALog)
-      {
+      if ($LastPALog) {
         $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Power Automate' -Classification 'Uncatalogued Technique N.12' -Path $PADFolder -Value $LastPALog -AccessGained 'System/User' -Note "'Power Automate' is an RPA (Robotic Process Automation) made available by Microsoft. It can runs on standalone system or through Azure Tenants. Given the high number of functions available and the 'legit source' of these executables and processes, it could be used for malicious intent as well. The presence of the logs means that the system is in some way running these flows. Review if they are legit or not (last log is shown in Value)." -Reference 'https://github.com/mbrg/defcon30/tree/main/No_Code_Malware'
         $null = $persistenceObjectArray.Add($PersistenceObject)
       }
@@ -1421,26 +1208,20 @@ function Find-AllPersistence
       Write-Verbose -Message '' 
     }
 
-    function Get-TSInitialProgram
-    {
+    function Get-TSInitialProgram {
       Write-Verbose -Message "$hostname - Getting Terminal Services InitialProgram properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $InitialProgram = Get-ItemProperty -Path "$hive\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" -Name InitialProgram
         $fInheritInitialProgram = Get-ItemProperty -Path "$hive\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" -Name fInheritInitialProgram 
-        if($null -ne $InitialProgram.InitialProgram -and $InitialProgram.InitialProgram.Length -ne 0 -and $fInheritInitialProgram -eq 1)
-        {
+        if ($null -ne $InitialProgram.InitialProgram -and $InitialProgram.InitialProgram.Length -ne 0 -and $fInheritInitialProgram -eq 1) {
           Write-Verbose -Message "$hostname - [!] Found InitialProgram property under the $(Convert-Path -Path $hive) Terminal Services key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $InitialProgram))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $InitialProgram)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $InitialProgram.PSPath
             $propPath += '\' + $prop.Name
-            if(Get-IfSafeExecutable $InitialProgram.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $InitialProgram.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Terminal Services InitialProgram' -Classification 'Uncatalogued Technique N.8' -Path $propPath -Value $InitialProgram.($prop.Name) -AccessGained 'System/User' -Note "The executable in the InitialProgram property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services is run when a Remote Desktop Connection is made to the target machine. Gained access depends on whether the key is in the system hive or a user's hive. For this technique to work, the fInheritInitialProgram property of the same key must also be set to 1." -Reference 'https://persistence-info.github.io/Data/tsinitialprogram.html' 
@@ -1450,19 +1231,15 @@ function Find-AllPersistence
     
         $InitialProgram = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" -Name InitialProgram 
         $fInheritInitialProgram = Get-ItemProperty -Path "$hive\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" -Name fInheritInitialProgram 
-        if($null -ne $InitialProgram.InitialProgram -and $InitialProgram.InitialProgram.Length -ne 0 -and $fInheritInitialProgram -eq 1)
-        {
+        if ($null -ne $InitialProgram.InitialProgram -and $InitialProgram.InitialProgram.Length -ne 0 -and $fInheritInitialProgram -eq 1) {
           Write-Verbose -Message "$hostname - [!] Found InitialProgram property under the $(Convert-Path -Path $hive) Terminal Services key which deserve investigation!"
-          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $InitialProgram))
-          {
-            if($psProperties.Contains($prop.Name)) 
-            {
+          foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $InitialProgram)) {
+            if ($psProperties.Contains($prop.Name)) {
               continue
             } # skip the property if it's powershell built-in property
             $propPath = Convert-Path -Path $InitialProgram.PSPath
             $propPath += '\' + $prop.Name
-            if(Get-IfSafeExecutable $InitialProgram.($prop.Name))
-            {
+            if (Get-IfSafeExecutable $InitialProgram.($prop.Name)) {
               continue
             }
             $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Terminal Services InitialProgram' -Classification 'Uncatalogued Technique N.8' -Path $propPath -Value $InitialProgram.($prop.Name) -AccessGained 'System/User' -Note "The executable in the InitialProgram property of (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services is run when a Remote Desktop Connection is made to the target machine. Gained access depends on whether the key is in the system hive or a user's hive. For this technique to work, the fInheritInitialProgram property of the same key must also be set to 1." -Reference 'https://persistence-info.github.io/Data/tsinitialprogram.html'
@@ -1473,8 +1250,7 @@ function Find-AllPersistence
       Write-Verbose -Message '' 
     }
     
-    function Get-AccessibilityTools
-    {   
+    function Get-AccessibilityTools {   
       Write-Verbose -Message "$hostname - Looking for accessibility tools backdoors..."
       
       $accessibilityTools = @(
@@ -1490,26 +1266,21 @@ function Find-AllPersistence
       $explorerHash = Get-FileHash -LiteralPath $env:windir\explorer.exe
       
       $backdoorHashes = [ordered]@{
-        $cmdHash.Hash = "$env:windir\System32\cmd.exe";
-        $psHash.Hash = "$env:windir\System32\WindowsPowerShell\v1.0\powershell.exe";
+        $cmdHash.Hash      = "$env:windir\System32\cmd.exe";
+        $psHash.Hash       = "$env:windir\System32\WindowsPowerShell\v1.0\powershell.exe";
         $explorerHash.Hash = "$env:windir\explorer.exe"
       }
       
-      foreach($tool in $accessibilityTools)
-      {
-        if((Get-AuthenticodeSignature -FilePath $tool).IsOSBinary -ne $true)
-        {
+      foreach ($tool in $accessibilityTools) {
+        if ((Get-AuthenticodeSignature -FilePath $tool).IsOSBinary -ne $true) {
           Write-Verbose -Message "$hostname - [!] Found a suspicious executable in place of of the accessibility tool $tool"
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Accessibility Tools Backdoor' -Classification 'MITRE ATT&CK T1546.008' -Path $tool -Value $tool -AccessGained 'System' -Note "Accessibility tools are executables that can be run from the lock screen of a Windows machine and are supposed to enable accessibility features like text to speech or zooming in on the screen. If an attacker replaces them with malicious or LOLBIN executables they can execute code with SYSTEM permission from a lock screen, effectively bypassing authentication. In this case, the accessibility tool in the Path field is not an OS executable, so it may have been replaced with a malicious, non-Microsoft executable." -Reference 'https://attack.mitre.org/techniques/T1546/008/'
           $null = $persistenceObjectArray.Add($PersistenceObject)
         }
-        else
-        {
+        else {
           $toolHash = Get-FileHash -LiteralPath $tool
-          foreach($hash in $backdoorHashes.Keys)
-          { 
-            if($toolHash.Hash -eq $hash)
-            {
+          foreach ($hash in $backdoorHashes.Keys) { 
+            if ($toolHash.Hash -eq $hash) {
               Write-Verbose -Message "$hostname - [!] Found a suspicious executable in place of of the accessibility tool $tool"
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Accessibility Tools Backdoor' -Classification 'MITRE ATT&CK T1546.008' -Path $tool -Value $backdoorHashes[$hash] -AccessGained 'System' -Note "Accessibility tools are executables that can be run from the lock screen of a Windows machine and are supposed to enable accessibility features like text to speech or zooming in on the screen. If an attacker replaces them with malicious or LOLBIN executables they can execute code with SYSTEM permission from a lock screen, effectively bypassing authentication. In this case, the accessibility tool in the Path field has been replaced with the binary in the Value field." -Reference 'https://attack.mitre.org/techniques/T1546/008/'
               $null = $persistenceObjectArray.Add($PersistenceObject)
@@ -1520,26 +1291,21 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-AMSIProviders
-    {
+    function Get-AMSIProviders {
       Write-Verbose -Message "$hostname - Getting AMSI providers..."
       $legitAMSIGUID = '{2781761E-28E0-4109-99FE-B9D127C57AFE}' # this is the GUID of Microsoft's legitimate AMSI provider
       $amsiProviders = Get-ChildItem -Path "HKLM:\SOFTWARE\Microsoft\AMSI\Providers\" 
-      foreach($key in $amsiProviders)
-      {
+      foreach ($key in $amsiProviders) {
         $keyGUID = $key.PSChildName
-        if($keyGUID -eq $legitAMSIGUID)
-        {
+        if ($keyGUID -eq $legitAMSIGUID) {
           continue
         }
         Write-Verbose -Message "$hostname - [!] Found an unknown AMSI provider under the key HKLM\SOFTWARE\Microsoft\AMSI\Providers\$keyGUID which deserves investigation!"
         $path = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Classes\CLSID\$keyGUID\InprocServer32" -Name '(Default)').'(Default)'
-        if (-not ($path -like '*.dll')) # if the DLL is specified without a .dll, append it
-        {
+        if (-not ($path -like '*.dll')) { # if the DLL is specified without a .dll, append it
           $path = $path + '.dll'
         }
-        if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) # if the DLL is specified without a path, assume it's under System32
-        {
+        if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) { # if the DLL is specified without a path, assume it's under System32
           $path = "C:\Windows\System32\$path"
         }
         $propPath = "HKLM:\SOFTWARE\Classes\CLSID\$keyGUID\InprocServer32\(Default)"
@@ -1550,36 +1316,29 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-PowershellProfiles
-    {
+    function Get-PowershellProfiles {
       Write-Verbose -Message "$hostname - Getting Powershell profiles..."
       $script:powershellProfilesArray = [Collections.ArrayList]::new()
       $systemProfile = Get-ChildItem 'C:\Windows\System32\WindowsPowerShell\v1.0\Profile.ps1'
       $microsoftSystemProfile = Get-ChildItem 'C:\Windows\System32\WindowsPowerShell\v1.0\Microsoft.PowerShell_profile.ps1'
-      if($systemProfile)
-      {
+      if ($systemProfile) {
         $null = $powershellProfilesArray.Add($systemProfile)
       }
-      if($microsoftSystemProfile)
-      {
+      if ($microsoftSystemProfile) {
         $null = $powershellProfilesArray.Add($microsoftSystemProfile)
       }
       $userDirectories = Get-ChildItem -Path 'C:\Users\'
-      foreach($directory in $userDirectories)
-      {
+      foreach ($directory in $userDirectories) {
         $userProfile = Get-ChildItem -Path "$($directory.FullName)\Documents\WindowsPowerShell\Profile.ps1"
-        if($userProfile)
-        {
+        if ($userProfile) {
           $null = $powershellProfilesArray.Add($userProfile)
         }
         $userProfile = Get-ChildItem -Path "$($directory.FullName)\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
-        if($userProfile)
-        {
+        if ($userProfile) {
           $null = $powershellProfilesArray.Add($userProfile)
         }
       }
-      foreach($profile in $powershellProfilesArray)
-      {
+      foreach ($profile in $powershellProfilesArray) {
         Write-Verbose -Message "$hostname - [!] Found a Powershell profile under $($profile.FullName) which deserves investigation!"
         $path = $profile
         $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Powershell Profile' -Classification 'MITRE ATT&CK T1546.013' -Path $path.DirectoryName -Value $path.FullName -AccessGained 'User' -Note "Files named 'Profile.ps1' or 'Microsoft.PowerShell_profile.ps1' under System32's Powershell directory or a user's Documents\WindowsPowerShell folder are loaded whenever a user launches Powershell."  -Reference 'https://attack.mitre.org/techniques/T1546/013/'
@@ -1588,20 +1347,17 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-SilentExitMonitor
-    {
+    function Get-SilentExitMonitor {
       Write-Verbose -Message "$hostname - Getting Silent exit monitors..."
       $exitMonitors = Get-ChildItem -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\"
-      foreach($key in $exitMonitors)
-      {
+      foreach ($key in $exitMonitors) {
         $monitoredApp = $key.PSPath
         $monitoringApp = (Get-ItemProperty $monitoredApp).MonitorProcess
         Write-Verbose -Message "$hostname - [!] Found a silently monitored process under HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\ which deserves investigation!"
         $propPath = Convert-Path -Path $monitoredApp
         $propPath += '\MonitorProcess'
         $path = $monitoringApp
-        if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) # if the exe is specified without a path, try to get it with Get-Command
-        {
+        if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) { # if the exe is specified without a path, try to get it with Get-Command
           $path = (Get-Command $path).Source
         }
         $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Silent Process Exit Monitor' -Classification 'MITRE ATT&CK T1546.012' -Path $propPath -Value $path -AccessGained 'System/User' -Note 'Executables specified under subkeys of HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\ are run when the process associated with the subkey is terminated by another process.' -Reference 'https://attack.mitre.org/techniques/T1546/012/'
@@ -1611,16 +1367,13 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-TelemetryController
-    {
+    function Get-TelemetryController {
       Write-Verbose -Message "$hostname - Getting Telemetry controllers..."
       $telemetryController = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController").Command
-      if($telemetryController)
-      {
+      if ($telemetryController) {
         $propPath = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController\Command'
         $path = $telemetryController
-        if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) # if the exe is specified without a path, try to get it with Get-Command
-        {
+        if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) { # if the exe is specified without a path, try to get it with Get-Command
           $path = (Get-Command $path).Source
         }
         $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Telemetry Controller Command' -Classification 'Uncatalogued Technique N.10' -Path $propPath -Value $path -AccessGained 'System' -Note "Executables specified under the Command property of HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController\ are run by the Windows Compatibility Telemetry's binary named CompatTelRunner.exe" -Reference 'https://www.trustedsec.com/blog/abusing-windows-telemetry-for-persistence/'
@@ -1629,23 +1382,18 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-RDPWDSStartupPrograms
-    {
+    function Get-RDPWDSStartupPrograms {
       Write-Verbose -Message "$hostname - Getting RDP WDS startup programs"
       $startupPrograms = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\Wds\rdpwd").StartupPrograms
-      if($startupPrograms)
-      {
+      if ($startupPrograms) {
         $executables = $startupPrograms.split(',')
-        foreach($exe in $executables)
-        {
-          if($exe -eq 'rdpclip')
-          {
+        foreach ($exe in $executables) {
+          if ($exe -eq 'rdpclip') {
             continue
           }
           $propPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\Wds\rdpwd\StartupPrograms'
           $path = $exe
-          if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) # if the exe is specified without a path, try to get it with Get-Command
-          {
+          if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) { # if the exe is specified without a path, try to get it with Get-Command
             $path = (Get-Command $path).Source
           }
           $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'RDP WDS Startup Programs' -Classification 'Uncatalogued Technique N.11' -Path $propPath -Value $path -AccessGained 'System' -Note "Executables specified under the StartupPrograms property of HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\Wds\rdpwd are run whenever a user logs on the machine through remote desktop." -Reference 'https://persistence-info.github.io/Data/rdpwdstartupprograms.html'
@@ -1655,23 +1403,18 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-ScheduledTasks
-    {
+    function Get-ScheduledTasks {
       Write-Verbose -Message "$hostname - Getting scheduled tasks"
       $tasks = Get-ScheduledTask
-      if($tasks)
-      {
-        foreach($task in $tasks)
-        {
+      if ($tasks) {
+        foreach ($task in $tasks) {
           $propPath = $task.TaskPath
           $propPath += $task.TaskName
           $path = ($task.Actions).Execute + " " + ($task.Actions).Arguments
-          if($task.UserId -eq 'SYSTEM')
-          {
+          if ($task.UserId -eq 'SYSTEM') {
             $access = 'System'
           }
-          else
-          {
+          else {
             $access = 'User'
           }
           
@@ -1682,22 +1425,17 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
 
-    function Get-BitsJobsNotifyCmdLine
-    {
+    function Get-BitsJobsNotifyCmdLine {
       Write-Verbose -Message "$hostname - Getting BITS Jobs"
-      $jobs =  Get-BitsTransfer -AllUsers | Where-Object {$_.JobState -eq "Error" } | Where-Object {$_.NotifyCmdLine.Length -gt 0}
-      if($jobs)
-      {
-        foreach($job in $jobs)
-        {
+      $jobs = Get-BitsTransfer -AllUsers | Where-Object { $_.JobState -eq "Error" } | Where-Object { $_.NotifyCmdLine.Length -gt 0 }
+      if ($jobs) {
+        foreach ($job in $jobs) {
           $propPath += $job.JobId
           $path = $job.NotifyCmdLine
-          if($job.OwnerAccount -eq 'NT AUTHORITY\SYSTEM')
-          {
+          if ($job.OwnerAccount -eq 'NT AUTHORITY\SYSTEM') {
             $access = 'System'
           }
-          else
-          {
+          else {
             $access = 'User'
           }
           
@@ -1708,15 +1446,12 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-Screensaver
-    {
+    function Get-Screensaver {
       Write-Verbose -Message "$hostname - Getting Screensaver programs"
-      foreach($sid in $systemAndUsersHives) 
-      {
+      foreach ($sid in $systemAndUsersHives) {
         $legitimatePrograms = "C:\Windows\system32\Mystify.scr", "C:\Windows\system32\Ribbons.scr", "C:\Windows\system32\Bubbles.scr", "C:\Windows\system32\ssText3d.scr", "C:\Windows\system32\scrnsave.scr", "C:\Windows\system32\PhotoScreensaver.scr"
         $screenSaverProgram = (Get-ItemProperty -ErrorAction SilentlyContinue -Path "$sid\Control Panel\Desktop\" -Name "SCRNSAVE.exe")
-        if(($screenSaverProgram) -and ($screenSaverProgram."SCRNSAVE.EXE" -ne ""))
-        {
+        if (($screenSaverProgram) -and ($screenSaverProgram."SCRNSAVE.EXE" -ne "")) {
           $executable = $screenSaverProgram."SCRNSAVE.EXE"
           if ($legitimatePrograms.Contains($Executable)) {
             continue
@@ -1731,19 +1466,16 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-OfficeTemplates
-    {
+    function Get-OfficeTemplates {
       Write-Verbose -Message "$hostname - Checking if users' Office folders contains interesting templates..."
       $userDirectories = Get-ChildItem -Path 'C:\Users\'
-      foreach($directory in $userDirectories)
-      {
+      foreach ($directory in $userDirectories) {
         $addins = Get-ChildItem -Path "$($directory.FullName)\AppData\Roaming\Microsoft\Word\STARTUP\" 
         $addins += Get-ChildItem -Path "$($directory.FullName)\AppData\Roaming\Microsoft\Templates\" -Filter *.dotm
         $addins += Get-ChildItem -Path "$($directory.FullName)\AppData\Roaming\Microsoft\Excel\XLSTART\"
         $addins += Get-ChildItem -Path "$($directory.FullName)\AppData\Roaming\Microsoft\AddIns\"
         $addins += Get-ChildItem -Path "$($directory.FullName)\AppData\Roaming\Microsoft\Outlook\" -Filter *.OTM
-        foreach($file in $addins)
-        {
+        foreach ($file in $addins) {
           $fullname = $file.FullName
           $path = Split-Path -Path $fullname
           Write-Verbose -Message "$hostname - Found $fullname"
@@ -1754,14 +1486,11 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-ExplorerContextMenu
-    {
+    function Get-ExplorerContextMenu {
       Write-Verbose -Message "$hostname - Checking for Explorer Context Menu hijacking..."
       $path = (Get-ItemProperty -Path "Registry::HKEY_CLASSES_ROOT\AllFilesystemObjects\shellex\ContextMenuHandlers\{B7CDF620-DB73-44C0-8611-832B261A0107}" -Name '(Default)').'(Default)'
-      if($null -ne $path)
-      {  
-        if(([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false)
-        {
+      if ($null -ne $path) {  
+        if (([System.IO.Path]::IsPathRooted([System.Environment]::ExpandEnvironmentVariables($path))) -eq $false) {
           $path = "C:\Windows\System32\$path"
         }
       
@@ -1773,15 +1502,13 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-ServiceControlManagerSecurityDescriptor
-    {
+    function Get-ServiceControlManagerSecurityDescriptor {
       Write-Verbose -Message "$hostname - Checking for manipulation of the security descriptor of the Service Control Manager..."
       
       $currentSDDL = (sc.exe sdshow scmanager) -join ''
       $defaultSDDL = 'D:(A;;CC;;;AU)(A;;CCLCRPRC;;;IU)(A;;CCLCRPRC;;;SU)(A;;CCLCRPWPRC;;;SY)(A;;KA;;;BA)(A;;CC;;;AC)(A;;CC;;;S-1-15-3-1024-528118966-3876874398-709513571-1907873084-3598227634-3698730060-278077788-3990600205)S:(AU;FA;KA;;;WD)(AU;OIIOFA;GA;;;WD)'
 
-      if($defaultSDDL -eq $currentSDDL)
-      {
+      if ($defaultSDDL -eq $currentSDDL) {
         return
       }
 
@@ -1791,8 +1518,7 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-MicrosoftOfficeAIHijacking
-    {
+    function Get-MicrosoftOfficeAIHijacking {
       Write-Verbose -Message "$hostname - Checking for the hijacking of the Microsoft Office AI.exe executable..."
       
       $officex64Dir = [System.Environment]::ExpandEnvironmentVariables('%ProgramFiles%\Microsoft Office\root\')
@@ -1802,10 +1528,8 @@ function Find-AllPersistence
       $paths = @(Get-ChildItem $officex64Dir)
       $paths += @(Get-ChildItem $officex86Dir)
       
-      foreach($path in $paths)
-      {  
-        if((Test-Path -Path "$($path.FullName)\ai.exe") -eq $false)
-        {
+      foreach ($path in $paths) {  
+        if ((Test-Path -Path "$($path.FullName)\ai.exe") -eq $false) {
           continue
         }
       
@@ -1818,39 +1542,30 @@ function Find-AllPersistence
       Write-Verbose -Message ''
     }
     
-    function Get-RunExAndRunOnceEx
-    {
+    function Get-RunExAndRunOnceEx {
       Write-Verbose -Message "$hostname - Getting Run properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $runKeys = Get-ChildItem -Path "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\RunEx"
-        foreach($key in $runKeys)
-        {
+        foreach ($key in $runKeys) {
           Write-Verbose -Message "$hostname - [!] Found keys under $(Convert-Path -Path $hive)'s RunEx key which deserve investigation!"
           $runProps = Get-ItemProperty -Path $key.PSPath 
-          if($runProps)
-          {
+          if ($runProps) {
             Write-Verbose -Message "$hostname - [!] Found properties under a key in $(Convert-Path -Path $hive)'s RunEx key which deserve investigation!"
-            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runProps))
-            {
-              if($psProperties.Contains($prop.Name)) 
-              {
+            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runProps)) {
+              if ($psProperties.Contains($prop.Name)) {
                 continue
               } # skip the property if it's powershell built-in property
               $propPath = Convert-Path -Path $runProps.PSPath
               $propPath += '\' + $prop.Name
               $currentHive = Convert-Path -Path $hive
-              if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-              {
+              if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
                 $access = 'System'
               }
-              else
-              {
+              else {
                 $access = 'User'
               }
             
-              if(Get-IfSafeExecutable $runProps.($prop.Name))
-              {
+              if (Get-IfSafeExecutable $runProps.($prop.Name)) {
                 continue
               }
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Registry RunEx Key' -Classification 'MITRE ATT&CK T1547.001' -Path $propPath -Value $runProps.($prop.Name) -AccessGained $access -Note 'Executables in properties of any key under the (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\CurrentVersion\RunEx key are run when the user logs in or when the machine boots up (in the case of the HKLM hive).' -Reference 'https://attack.mitre.org/techniques/T1547/001/' 
@@ -1862,36 +1577,28 @@ function Find-AllPersistence
     
       Write-Verbose -Message ''
       Write-Verbose -Message "$hostname - Getting RunOnce properties..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $runOnceKeys = Get-ChildItem -Path "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx"
-        foreach($key in $runOnceKeys)
-        {
+        foreach ($key in $runOnceKeys) {
           Write-Verbose -Message "$hostname - [!] Found keys under $(Convert-Path -Path $hive)'s RunOnceEx key which deserve investigation!"
           $runOnceProps = Get-ItemProperty -Path $key.PSPath
          
-          if($runOnceProps)
-          {
+          if ($runOnceProps) {
             Write-Verbose -Message "$hostname - [!] Found properties under a key in $(Convert-Path -Path $hive)'s RunOnceEx key which deserve investigation!"
-            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runOnceProps))
-            {
-              if($psProperties.Contains($prop.Name)) 
-              {
+            foreach ($prop in (Get-Member -MemberType NoteProperty -InputObject $runOnceProps)) {
+              if ($psProperties.Contains($prop.Name)) {
                 continue
               } # skip the property if it's powershell built-in property
               $propPath = Convert-Path -Path $runOnceProps.PSPath
               $propPath += '\' + $prop.Name
               $currentHive = Convert-Path -Path $hive
-              if(($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20'))
-              {
+              if (($currentHive -eq 'HKEY_LOCAL_MACHINE') -or ($currentHive -eq 'HKEY_USERS\S-1-5-18') -or ($currentHive -eq 'HKEY_USERS\S-1-5-19') -or ($currentHive -eq 'HKEY_USERS\S-1-5-20')) {
                 $access = 'System'
               }
-              else
-              {
+              else {
                 $access = 'User'
               }
-              if(Get-IfSafeExecutable $runOnceProps.($prop.Name))
-              {
+              if (Get-IfSafeExecutable $runOnceProps.($prop.Name)) {
                 continue
               }
               $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique 'Registry RunOnceEx Key' -Classification 'MITRE ATT&CK T1547.001' -Path $propPath -Value $runOnceProps.($prop.Name) -AccessGained $access -Note 'Executables in properties of any key under the (HKLM|HKEY_USERS\<SID>)\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx key are run when the user logs in or when the machine boots up (in the case of the HKLM hive), and then deleted.' -Reference 'https://attack.mitre.org/techniques/T1547/001/' 
@@ -1902,18 +1609,14 @@ function Find-AllPersistence
       }
       Write-Verbose -Message ''
     }
-    function Get-DotNetStartupHooks
-    {
+    function Get-DotNetStartupHooks {
       Write-Verbose -Message "$hostname - Getting DotNet Startup Hooks..."
-      foreach($hive in $systemAndUsersHives)
-      {
+      foreach ($hive in $systemAndUsersHives) {
         $dotnetHooks = (Get-ItemProperty -Path "$hive\Environment" -Name DOTNET_STARTUP_HOOKS).DOTNET_STARTUP_HOOKS
-        if($dotnetHooks)
-        {
+        if ($dotnetHooks) {
           $dotnetHooks = $dotnetHooks -split ';'
         }
-        foreach($hook in $dotnetHooks)
-        {
+        foreach ($hook in $dotnetHooks) {
           Write-Verbose -Message "$hostname - [!] Found a .NET hook in the DOTNET_STARTUP_HOOKS property in the $(Convert-Path -Path $hive)\Environment key!"
           $propPath = Convert-Path -Path $hive
           $propPath += "\Environment\DOTNET_STARTUP_HOOKS"
@@ -1923,12 +1626,10 @@ function Find-AllPersistence
       }
       
       $systemHooks = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name DOTNET_STARTUP_HOOKS).DOTNET_STARTUP_HOOKS
-      if($systemHooks)
-      {
+      if ($systemHooks) {
         $systemHooks = $systemHooks -split ';'
       }
-      foreach($hook in $systemHooks)
-      {
+      foreach ($hook in $systemHooks) {
         Write-Verbose -Message "$hostname - [!] Found a .NET hook in the DOTNET_STARTUP_HOOKS property in the $(Convert-Path -Path $hive)\Environment key!"
         $propPath = "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
         $PersistenceObject = New-PersistenceObject -Hostname $hostname -Technique '.NET Startup Hooks DLL Sideloading' -Classification 'MITRE ATT&CK T1574.002' -Path $propPath -Value $hook -AccessGained 'User/System' -Note 'The .NET DLLs listed in the DOTNET_STARTUP_HOOKS environment variable are loaded into .NET processes at runtime.' -Reference 'https://persistence-info.github.io/Data/dotnetstartuphooks.html'
@@ -1940,8 +1641,7 @@ function Find-AllPersistence
 
     Write-Verbose -Message "$hostname - Starting execution..."
 
-    if($PersistenceMethod -eq 'All')
-    {
+    if ($PersistenceMethod -eq 'All') {
       Get-RunAndRunOnce
       Get-ImageFileExecutionOptions
       Get-NLDPDllOverridePath
@@ -1988,8 +1688,7 @@ function Find-AllPersistence
       Get-RunExAndRunOnceEx
       Get-DotNetStartupHooks
       
-      if($IncludeHighFalsePositivesChecks.IsPresent)
-      {
+      if ($IncludeHighFalsePositivesChecks.IsPresent) {
         Write-Verbose -Message "$hostname - You have used the -IncludeHighFalsePositivesChecks switch, this may generate a lot of false positives since it includes checks with results which are difficult to filter programmatically..."
         Get-AppPaths
         Get-WindowsServices
@@ -1997,259 +1696,207 @@ function Find-AllPersistence
       }
     }
     
-    else
-    {
-      switch($PersistenceMethod)
-      {
-        'RunAndRunOnce'
-        {
+    else {
+      switch ($PersistenceMethod) {
+        'RunAndRunOnce' {
           Get-RunAndRunOnce
           break
         }
-        'ImageFileExecutionOptions'
-        {
+        'ImageFileExecutionOptions' {
           Get-ImageFileExecutionOptions
           break
         }
-        'NLDPDllOverridePath'
-        {
+        'NLDPDllOverridePath' {
           Get-NLDPDllOverridePath
           break
         }
-        'AeDebug'
-        {
+        'AeDebug' {
           Get-AeDebug
           break
         }
-        'WerFaultHangs'
-        {
+        'WerFaultHangs' {
           Get-WerFaultHangs
           break
         }
-        'CmdAutoRun'
-        {
+        'CmdAutoRun' {
           Get-CmdAutoRun
           break
         }
-        'ExplorerLoad'
-        {
+        'ExplorerLoad' {
           Get-ExplorerLoad
           break
         }
-        'WinlogonUserinit'
-        {
+        'WinlogonUserinit' {
           Get-WinlogonUserinit
           break
         }
-        'WinlogonShell'
-        {
+        'WinlogonShell' {
           Get-WinlogonShell
           break
         }
-        'TerminalProfileStartOnUserLogin'
-        {
+        'TerminalProfileStartOnUserLogin' {
           Get-TerminalProfileStartOnUserLogin
           break
         }
-        'AppCertDlls'
-        {
+        'AppCertDlls' {
           Get-AppCertDlls
           break
         }
-        'ServiceDlls'
-        {
+        'ServiceDlls' {
           Get-ServiceDlls
           break
         }
-        'GPExtensionDlls'
-        {
+        'GPExtensionDlls' {
           Get-GPExtensionDlls
           break
         }
-        'WinlogonMPNotify'
-        {
+        'WinlogonMPNotify' {
           Get-WinlogonMPNotify
           break
         }
-        'CHMHelperDll'
-        {
+        'CHMHelperDll' {
           Get-CHMHelperDll
           break
         }
-        'HHCtrlHijacking'
-        {
+        'HHCtrlHijacking' {
           Get-HHCtrlHijacking
           break
         }
-        'StartupPrograms'
-        {
+        'StartupPrograms' {
           Get-StartupPrograms
           break
         }
-        'UserInitMprScript'
-        {
+        'UserInitMprScript' {
           Get-UserInitMprScript
           break
         }
-        'AutodialDLL'
-        {
+        'AutodialDLL' {
           Get-AutodialDLL
           break
         }
-        'LsaExtensions'
-        {
+        'LsaExtensions' {
           Get-LsaExtensions       
           break  
         }
-        'ServerLevelPluginDll'
-        {
+        'ServerLevelPluginDll' {
           Get-ServerLevelPluginDll
           break        
         }
-        'LsaPasswordFilter'
-        {
+        'LsaPasswordFilter' {
           Get-LsaPasswordFilter
           break         
         }
-        'LsaAuthenticationPackages'
-        {
+        'LsaAuthenticationPackages' {
           Get-LsaAuthenticationPackages
           break          
         }
-        'LsaSecurityPackages'
-        {
+        'LsaSecurityPackages' {
           Get-LsaSecurityPackages 
           break         
         }
-        'WinlogonNotificationPackages'
-        {
+        'WinlogonNotificationPackages' {
           Get-WinlogonNotificationPackages
           break          
         }
-        'ExplorerTools'
-        {
+        'ExplorerTools' {
           Get-ExplorerTools
           break          
         }
-        'DotNetDebugger'
-        {
+        'DotNetDebugger' {
           Get-DotNetDebugger
           break         
         }
-        'ErrorHandlerCmd'
-        {
+        'ErrorHandlerCmd' {
           Get-ErrorHandlerCmd
           break
         }
-        'WMIEventsSubscrition'
-        {
+        'WMIEventsSubscrition' {
           Get-WMIEventsSubscrition
           break
         }
-        'WindowsServices'
-        {
+        'WindowsServices' {
           Get-WindowsServices
           break
         }
-        'AppPaths'
-        {
+        'AppPaths' {
           Get-AppPaths
           break
         }
-        'TerminalServicesInitialProgram'
-        {
+        'TerminalServicesInitialProgram' {
           Get-TSInitialProgram
           break
         }
-        'AccessibilityTools'
-        {
+        'AccessibilityTools' {
           Get-AccessibilityTools
           break
         }
-        'AMSIProviders'
-        {
+        'AMSIProviders' {
           Get-AMSIProviders
           break
         }
-        'PowershellProfiles'
-        {
+        'PowershellProfiles' {
           Get-PowershellProfiles
           break
         }
-        'SilentExitMonitor'
-        {
+        'SilentExitMonitor' {
           Get-SilentExitMonitor
           break
         }
-        'TelemetryController'
-        {
+        'TelemetryController' {
           Get-TelemetryController
           break
         }
-        'RDPWDSStartupPrograms'
-        {
+        'RDPWDSStartupPrograms' {
           Get-RDPWDSStartupPrograms
           break
         }
-        'ScheduledTasks'
-        {
+        'ScheduledTasks' {
           Get-ScheduledTasks
           break
         }
 
-        'Screensaver'
-        {
+        'Screensaver' {
           Get-Screensaver
           break
         }
 
-        'BitsJobsNotify'
-        {
+        'BitsJobsNotify' {
           Get-BitsJobsNotifyCmdLine
           break
         }
-        'PowerAutomate'
-        {
+        'PowerAutomate' {
           Get-PowerAutomate
           break
         }
-        'Services'
-        {
+        'Services' {
           Get-WindowsServices 
           break
         }
-        'ScheduledTasks'
-        {
+        'ScheduledTasks' {
           Get-ScheduledTasks
           break
         }
-        'OfficeAddinsAndTemplates'
-        {
+        'OfficeAddinsAndTemplates' {
           Get-OfficeTemplates
           break
         }
-        'ExplorerContextMenu'
-        {
+        'ExplorerContextMenu' {
           Get-ExplorerContextMenu
           break
         }
-        'ServiceControlManagerSD'
-        {
+        'ServiceControlManagerSD' {
           Get-ServiceControlManagerSecurityDescriptor
           break
         }
-        'OfficeAiHijacking'
-        {
+        'OfficeAiHijacking' {
           Get-MicrosoftOfficeAIHijacking
           break
         }
-        'RunExAndRunOnceEx'
-        {
+        'RunExAndRunOnceEx' {
           Get-RunExAndRunOnceEx
           break
         }
-        'DotNetStartupHooks'
-        {
+        'DotNetStartupHooks' {
           Get-DotNetStartupHooks
           break
         }
@@ -2258,24 +1905,19 @@ function Find-AllPersistence
     
     Write-Verbose -Message "$hostname - Execution finished, outputting results..."
     # Use Input CSV to make a diff of the results and only show us the persistences implanted on the local machine which are not in the CSV
-    if($DiffCSV)
-    {
+    if ($DiffCSV) {
       Write-Verbose -Message 'Diffing found persistences with the ones in the input CSV...'
       $importedPersistenceObjectArray = Import-Csv -Path $DiffCSV -ErrorAction Stop
       $newPersistenceObjectArray = New-Object -TypeName System.Collections.ArrayList
-      foreach($localPersistence in $persistenceObjectArray)
-      {
+      foreach ($localPersistence in $persistenceObjectArray) {
         $found = $false
-        foreach($importedPersistence in $importedPersistenceObjectArray)
-        {
-          if(($importedPersistence.Technique -eq $localPersistence.Technique) -and ($importedPersistence.Path -eq $localPersistence.Path) -and ($importedPersistence.Value -eq $localPersistence.Value))
-          {
+        foreach ($importedPersistence in $importedPersistenceObjectArray) {
+          if (($importedPersistence.Technique -eq $localPersistence.Technique) -and ($importedPersistence.Path -eq $localPersistence.Path) -and ($importedPersistence.Value -eq $localPersistence.Value)) {
             $found = $true
             break
           }
         }
-        if($found -eq $false)
-        {
+        if ($found -eq $false) {
           $null = $newPersistenceObjectArray.Add($localPersistence)
         }
       }
@@ -2284,25 +1926,122 @@ function Find-AllPersistence
     $persistenceObjectArray
   }
   
-  if($ComputerName)
-  {
+  if ($ComputerName) {
     Invoke-Command -ComputerName $ComputerName -ScriptBlock $ScriptBlock -ErrorAction Continue
   }
-  else
-  {
+  else {
     Invoke-Command -ScriptBlock $ScriptBlock
   }
   
   
   
-  if($OutputCSV)
-  {
+  if ($OutputCSV) {
     $persistenceObjectArray |
     ConvertTo-Csv -NoTypeInformation |
     Out-File -FilePath $OutputCSV -ErrorAction Stop
   }
+
+  if ($OutputETW) {
+    WriteFindingsToEtw -Findings $persistenceObjectArray
+  }
   
   Write-Verbose -Message 'Script execution finished.'  
+}
+
+
+function WriteFindingsToEtw {
+  
+  Param (
+    
+    [Parameter(Mandatory = $true)]
+    [Collections.ArrayList]$Findings
+
+  )
+  
+  Begin {
+    $EventIDMapping = @{
+      'Registry Run Key'                                          = $null
+      'Registry RunOnce Key'                                      = $null
+      'Image File Execution Options'                              = $null
+      'Natural Language Development Platform 6 DLL Override Path' = $null
+      'AEDebug Custom Debugger'                                   = $null
+      'Wow6432Node AEDebug Custom Debugger'                       = $null
+      'Windows Error Reporting Debugger'                          = $null
+      'Windows Error Reporting ReflectDebugger'                   = $null
+      'Command Processor AutoRun key'                             = $null
+      'Explorer Load Property'                                    = $null
+      'Winlogon Userinit Property'                                = $null
+      'Winlogon Shell Property'                                   = $null
+      'Windows Terminal startOnUserLogin'                         = $null
+      'AppCertDlls'                                               = $null
+      'App Paths'                                                 = $null
+      'ServiceDll Hijacking'                                      = $null
+      'Group Policy Extension DLL'                                = $null
+      'Winlogon MPNotify Executable'                              = $null
+      'CHM Helper DLL'                                            = $null
+      'Hijacking of hhctrl.ocx'                                   = $null
+      'Startup Folder'                                            = $null
+      'User Init Mpr Logon Script'                                = $null
+      'AutodialDLL Winsock Injection'                             = $null
+      'LSA Extensions DLL'                                        = $null
+      'ServerLevelPluginDll DNS Server DLL Hijacking'             = $null
+      'LSA Password Filter DLL'                                   = $null
+      'LSA Authentication Package DLL'                            = $null
+      'LSA Security Package DLL'                                  = $null
+      'Winlogon Notification Package'                             = $null
+      'Explorer Tools Hijacking'                                  = $null
+      'DbgManagedDebugger Custom Debugger'                        = $null
+      'Wow6432Node DbgManagedDebugger Custom Debugger'            = $null
+      'ErrorHandler.cmd Hijacking'                                = $null
+      'WMI Event Subscription'                                    = $null
+      'Windows Service'                                           = $null
+      'Power Automate'                                            = $null
+      'Terminal Services InitialProgram'                          = $null
+      'Accessibility Tools Backdoor'                              = $null
+      'Fake AMSI Provider'                                        = $null
+      'Powershell Profile'                                        = $null
+      'Silent Process Exit Monitor'                               = $null
+      'Telemetry Controller Command'                              = $null
+      'RDP WDS Startup Programs'                                  = $null
+      'Scheduled Task'                                            = $null
+      'BITS Job NotifyCmdLine'                                    = $null
+      'Suspicious Screensaver Program'                            = $null
+      'Office Application Startup'                                = $null
+      'Service Control Manager Security Descriptor Manipulation'  = $null
+      'Microsoft Office AI.exe Hijacking'                         = $null
+    }
+
+    # Collect the keys in a separate list
+    $keys = $EventIDMapping.Keys | ForEach-Object { $_ }
+
+    $i = 1000
+    foreach ($key in $keys) {
+      $EventIDMapping[$key] = $i
+      $i++
+    }
+  }
+  
+  Process {
+    $evtlog = "Application"
+    $source = "PersistenceSniper"
+          
+  
+    if ([System.Diagnostics.EventLog]::SourceExists($source) -eq $false) {
+      [System.Diagnostics.EventLog]::CreateEventSource($source, $evtlog)
+    }
+  
+    foreach ($finding in $Findings) {
+      $evtID = $EventIDMapping[$finding.technique]
+      $id = New-Object System.Diagnostics.EventInstance($evtID, 1); # Info Event
+      $propertiesValue = $finding.PSObject.Properties | Select-Object -ExpandProperty Value
+      $evtObject = New-Object System.Diagnostics.EventLog;
+      $evtObject.Log = $evtlog;
+      $evtObject.Source = $source;
+      $evtObject.WriteEvent($id, $propertiesValue)
+    }
+  }
+
+
 }
 # SIG # Begin signature block
 # MIIVlQYJKoZIhvcNAQcCoIIVhjCCFYICAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB


### PR DESCRIPTION
To avoid a deep tool modification submitted [here](https://github.com/last-byte/PersistenceSniper/pull/17), I created this pull request to add the support only for the ETW interfacing.

In detail, I added a switch argument allowing PersistenceSniper to log entries inside the **Application** channel.

`Find-AllPersistence -OutputETW`

![Screenshot from 2023-05-15 13-28-10](https://github.com/last-byte/PersistenceSniper/assets/90195154/141f154e-ced3-4b92-bf14-f7996bc34314)

![Screenshot from 2023-05-15 13-29-30](https://github.com/last-byte/PersistenceSniper/assets/90195154/d95da06d-9f19-4b30-b8fb-6659722b5c45)
