### PR TITLE
Username containing whitespaces causes suborner attack false-positive

### DIFF
--- a/PersistenceSniper/PersistenceSniper.psm1
+++ b/PersistenceSniper/PersistenceSniper.psm1
@@ -430,11 +430,10 @@ function Find-AllPersistence {
         }
 
         $contentArray = @()
-        foreach ($line in $item) {
-          while ($line.Contains("  ")) {
-            $line = $line -replace '  ', ' '
-          }
-          $contentArray += $line.Split(' ')
+        foreach ($line in $item -split '\s{2,}') {
+            if ($line -ne '') {
+                $contentArray += $line
+            }
         }
  
         foreach ($content in $contentArray) {


### PR DESCRIPTION
Hi,

I provide the project with a fix for a false-positive in the suborner attack caused by a whitespace in the username. This is being caused by a faulty splitting implementation in the `Parse-NetUser` function.

I tried to keep in touch with your coding style. Another style of fix would possibly be:

```
$contentArray += $item| ForEach-Object {
    $_ -split '\s{2,}' | Where-Object { $_ -ne '' }
}
```

**Setup**

PersistenceSniper 1.15.1

**Actual behavior**

I have a user on my test machine called "<name> <surname>". Running the suborner attack checks results in a detection because the user gets splitted into two users 1. <name> 2. <surname>.

**Expected behavior**

Users with a whitespace in their name should not cause a suborner attack detection. They should be represented as "<name> <surname>".

**Root cause**

I disovered, that the problem is rooted in the function "parse-netuser". The splitting mechanism causes the whitespace username to be splitted into two seperate accounts. This has been fixed by this pull request.